### PR TITLE
Solve a client-side inventory crash when calling Player.ClearInventory()

### DIFF
--- a/src/Libraries/Player.cs
+++ b/src/Libraries/Player.cs
@@ -434,10 +434,25 @@ namespace Oxide.Game.Rust.Libraries
         public PlayerInventory Inventory(BasePlayer player) => player.inventory;
 
         /// <summary>
+        /// Resets the inventory of the player
+        /// </summary>
+        /// <param name="player"></param>
+        public void ResetInventory(BasePlayer player)
+        {
+            PlayerInventory inventory = Inventory(player);
+
+            if (inventory != null)
+            {
+                inventory.DoDestroy();
+                inventory.ServerInit(player);
+            }
+        }
+
+        /// <summary>
         /// Clears the inventory of the player
         /// </summary>
         /// <param name="player"></param>
-        public void ClearInventory(BasePlayer player) => Inventory(player)?.DoDestroy();
+        public void ClearInventory(BasePlayer player) => Inventory(player)?.Strip();
 
         #endregion Inventory Handling
     }


### PR DESCRIPTION
- Add a new inventory reset method
- Update the clear method to solve a client-side crash