### PR TITLE
Added 3rd Arg (PlayerInventory) to OnItemAction

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3794,7 +3794,7 @@
             "InjectionIndex": 15,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "l2, l1",
+            "ArgumentString": "l2, l1, this",
             "HookTypeName": "Simple",
             "Name": "OnItemAction",
             "HookName": "OnItemAction",


### PR DESCRIPTION
Without the 3rd argument, there is no way to figure out what player is using an item when the item is in a storage container or another player's inventory.