### PR TITLE
Added return behavior to OnBuyVendingItem()

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3395,7 +3395,7 @@
           "Type": "Simple",
           "Hook": {
             "InjectionIndex": 8,
-            "ReturnBehavior": 0,
+            "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player, l0, l1",
             "HookTypeName": "Simple",


### PR DESCRIPTION
Allows plugins to stop a player from buying an item from a vending machine.

This also allows plugins to make vending machines exchange their item instantly, instead of waiting 2 seconds per transaction.