### PR TITLE
Changed CanExperiment hook.

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -6483,13 +6483,13 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 12,
+            "InjectionIndex": 107,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "l0, this.pendingBlueprint",
+            "ArgumentString": "this,l0, this.pendingBlueprint",
             "HookTypeName": "Simple",
-            "Name": "CanExperiment",
-            "HookName": "CanExperiment",
+            "Name": "OnExperiment",
+            "HookName": "OnExperiment",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "Workbench",
             "Flagged": false,


### PR DESCRIPTION
Changed the CanExperiment hook a bit.
1. Now - it would be called way later, to the point there pendingBlueprint would be chosen already.
2. Added this as a hook argument 
3. Renamed to the OnExperiment to better reflect the changes.