### PR TITLE
New hook: OnItemRemove

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7126,6 +7126,32 @@
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 1,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this",
+            "HookTypeName": "Simple",
+            "Name": "OnItemRemove",
+            "HookName": "OnItemRemove",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Item",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Remove",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "lPRt+cTi2ZCjTdaa7IZBhfQz3EMetXLrnfhA3ZuJPL0=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
This hook would be called then ITEM would be destroyed.
What is the difference with `OnEntityKill`? Simple enought - `OnEntityKill` is being called then BaseNetworkable is being destroyed.
Item is a seperated class.

For example - I'm creating a list of an items, and wanna keep my eyes on them even after restart. What should I do? The easies way - store the list of their net ID (Item.uid). But - how would I know if the item is still exists? Then should I remove it from the list? No idea.
As then you drop an item - the game create baseentity wich holds the item. 
Then entity is being destroyed every time you pick this item. Example:
```csharp
void OnEntityKill(BaseNetworkable entity) 
{ 
	if (entity?.net?.ID == null) return; 
		PrintWarning($"Killed entity {entity.net.ID}({entity.ShortPrefabName})"); 
		
	if (_items.Contains(entity.net.ID)) 
	{ 
		_items.Remove(entity.net.ID); 
		PrintWarning($"Removing item {entity.net.ID}"); 
	} 
} 

void OnItemDropped(Item item, BaseEntity entity) 
{ 
	PrintWarning($"Item {item} dropped! Entity: {entity}"); 
}
```
```
(21:56:30) | [Quests] Item Item.woodx100.2522392 dropped! Entity: generic_world[2522395] wood (world) 
(21:56:31) | [Quests] Killed entity 2522395(generic_world)
(21:57:32) | [Quests] Item Item.hatchetx1.2522870 dropped! Entity: generic_world[2522878] hatchet (world) 
(21:57:36) | [Quests] Killed entity 2522871(hatchet.entity)
```

And with this hook:
```csharp
        private ulong netid;
        [ChatCommand("setitem")]
        private void CmdSetItem(BasePlayer player)
        {
            var item = player.GetActiveItem();
            if (item == null)
            {
                player.ChatMessage("You have to active item!");
                return;
            }

            netid = item.uid;
            player.ChatMessage($"Item netid set to {item}");
            PrintWarning($"Item netid set to {item}");
        }
        object OnItemRemove(Item item)
        {
            if (item.uid == netid)
            {
                PrintWarning($"Item {item} is about to die!");
                PrintWarning("But this is our item, so - not gonna happen.");
                return false;
            }

           return null;
        }
```
```
(23:13:11) | [test] Item netid set to Item.rifle.boltx0.2561437
(23:13:26) | [test] Item Item.rifle.boltx0.2561437 is about to die!
```

But of course there is a downside - if one would return false in this hook while held entity is being destroyed (ex: item despawn, or item dropped out of map) - the item would still exist.
I'm not sure that it would be saved tho, but this can cause troubles if the plugin won't handle such situation (ex: if the items is being destroyed - drop it before returning null)

This hook for sure would be usefull even if it won't have return behaviou, but it would still be nice to be able to stop item destruction process.