### PR TITLE
Ability to change max health of murderer NPC

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7126,6 +7126,45 @@
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 1,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|BaseCombatEntity|_maxHealth"
+              },
+              {
+                "OpCode": "ret",
+                "OpType": "None",
+                "Operand": null
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "NPCMurderer_MaxHealthFix [patch]",
+            "HookName": "NPCMurderer_MaxHealthFix [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCMurderer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "MaxHealth",
+              "ReturnType": "System.Single",
+              "Parameters": []
+            },
+            "MSILHash": "Y05ykFor8PFxxgseU/rKQ3smkwN7RilPPD0iZufi4SE=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
By default, Rust caps the maximum health of all murderers to 100 and skips the _maxHealth variable it uses for all other entities. This changes behavior so you can set the maximum health and have it work.