### PR TITLE
Fix for OnWireClear

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -9299,10 +9299,10 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 87,
+            "InjectionIndex": 74,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l4, l1, l2",
+            "ArgumentString": "a0.player, l4, l1, l2, l6",
             "HookTypeName": "Simple",
             "Name": "OnWireClear",
             "HookName": "OnWireClear",


### PR DESCRIPTION
I don't really wanna spend another day trying to figure out why this is happening, but still - if the injection is done on line 87 any attempt to clear existing connection would result in player being kicked for: `Disconnect Reason: RPC Error in RequestClear`
Followed by this message in the console: `InvalidProgramException: Invalid IL code in WireTool:RequestClear (BaseEntity/RPCMessage): IL_00fa: ret`

Once again - to check if the current version would work I just clone the dev branch, build it on my own machine and run compiled bundle on my server.
Patcher version: 2.0.256-develop