### PR TITLE
New Hook: OnCreateCorpse(BasePlayer, BaseCorpse)

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -9608,6 +9608,32 @@
             "BaseHookName": null,
             "HookCategory": "Resource"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 110,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnCreateCorpse",
+            "HookName": "OnCreateCorpse",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnKilled",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "HitInfo"
+              ]
+            },
+            "MSILHash": "6cSIqUFQxIO3Fm6q1jsgbYfhEnWWGWB0MqHowgVQhcA=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
The hook is called for BasePlayer and all children of BasePlayer after their corpse is created.