### PR TITLE
Fixing OnVisibilityCheck hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -10066,13 +10066,14 @@
               "Name": "Test",
               "ReturnType": "System.Boolean",
               "Parameters": [
+                "System.UInt32",
                 "System.String",
                 "BaseEntity",
                 "BasePlayer",
                 "System.Single"
               ]
             },
-            "MSILHash": "ZxqoG8cIHQdpqnJ7Jao8igs0uCTwZ3G/Uv2l3vWP188=",
+            "MSILHash": "T1pa+k8VqlMF14rSDkWt4pL3oAcFSWWZNXbfohz5PJ0=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }


### PR DESCRIPTION
Previous method are no longer in use.
New signature is `uint, string, BaseEntity, BasePlayer, float`.