### PR TITLE
Added CanChangeSkin hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3622,6 +3622,32 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 22,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0.player, this, l2, l3",
+            "HookTypeName": "Simple",
+            "Name": "CanChangeSkin",
+            "HookName": "CanChangeSkin",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RepairBench",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ChangeSkin",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "RKKLW0k9FjxvYiUdARWOGRsRNENUApcixpbz43bRWdE=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 14,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,


### PR DESCRIPTION
Most of the developers when trying to make some unique items - use skins.
So if the player would change skin on the item - the plugin would have no way to check if it's unique or not.

There is another way - storing items uid, but in that case - this items won't work with most of the "backpack" type of plugins, as the original item would get destroyed.

```csharp
private object CanChangeSkin(BasePlayer player, RepairBench bench, int skin, Item item)
{
	Puts("CanChangeSkin works!");
	return null;
}
```