### PR TITLE
Moved OnGrowableGathered to earlier index

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -10261,7 +10261,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 26,
+            "InjectionIndex": 23,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l0, a0",


### PR DESCRIPTION
This would help those who want to change the item BEFORE it was giving to the player.
Example: changing amount.

If we would change amount after the item was given - the player would receive notification that he get original amount, as amount was changed after it was given.

This way - if we would change amount - the notification would show correct value, so we won't have to make another with the difference. 