### PR TITLE
TriggerParent hooks changed to TriggerComfort

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7930,15 +7930,15 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 14,
+            "InjectionIndex": 8,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 3,
             "ArgumentString": null,
             "HookTypeName": "Simple",
-            "Name": "OnEntityEnter [TriggerParent]",
+            "Name": "OnEntityEnter [TriggerComfort]",
             "HookName": "OnEntityEnter",
             "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "TriggerParent",
+            "TypeName": "TriggerComfort",
             "Flagged": false,
             "Signature": {
               "Exposure": 3,
@@ -7948,7 +7948,7 @@
                 "BaseEntity"
               ]
             },
-            "MSILHash": "0VHoxc+fHTGPGlucToJHsrY+ne5OZLVFmIcnoHfuD3I=",
+            "MSILHash": "Ha/G5PpnIvbeiGjoai70y6dOyGdWcHJjR4ol3F2Kq60=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -7956,15 +7956,15 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 3,
+            "InjectionIndex": 7,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 3,
             "ArgumentString": null,
             "HookTypeName": "Simple",
-            "Name": "OnEntityLeave [TriggerParent]",
+            "Name": "OnEntityLeave [TriggerComfort]",
             "HookName": "OnEntityLeave",
             "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "TriggerParent",
+            "TypeName": "TriggerComfort",
             "Flagged": false,
             "Signature": {
               "Exposure": 3,
@@ -7974,7 +7974,7 @@
                 "BaseEntity"
               ]
             },
-            "MSILHash": "Ip0M/qnc24HSTkam7+pUy5dYxPgAXi20j+8ix+0R4WM=",
+            "MSILHash": "OqpU6qb9r4hSsJkplO/D7vdXwWnZr+qEsbWZfM9v9TA=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }


### PR DESCRIPTION
The thing is - from all the triggers available, only TriggerComfort doesn't call the base OnEntity(Leave)Enter method of TriggerBase.

This means that in the current state - OnEntityEnter won't be called if the player entered TriggerComfort, and would be called twice on TriggerParent.
![image](https://user-images.githubusercontent.com/31519848/78507985-2a7a3400-778c-11ea-984a-b5bd03f3785e.png)
![image](https://user-images.githubusercontent.com/31519848/78507984-23ebbc80-778c-11ea-8534-36df09894fa1.png)
![image](https://user-images.githubusercontent.com/31519848/78507989-3239d880-778c-11ea-82a4-bb2d92cfc2db.png)
