### PR TITLE
Handling zero index in FindPlayers

### DIFF
--- a/src/Libraries/Covalence/RustPlayerManager.cs
+++ b/src/Libraries/Covalence/RustPlayerManager.cs
@@ -132,7 +132,7 @@ namespace Oxide.Game.Rust.Libraries.Covalence
                     break;
                 }
 
-                if (player.Name.IndexOf(partialNameOrId, StringComparison.OrdinalIgnoreCase) > 0)
+                if (player.Name.IndexOf(partialNameOrId, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     foundPlayers.Add(player);
                 }
@@ -151,7 +151,7 @@ namespace Oxide.Game.Rust.Libraries.Covalence
                     break;
                 }
 
-                if (player.Name.IndexOf(partialNameOrId, StringComparison.OrdinalIgnoreCase) > 0)
+                if (player.Name.IndexOf(partialNameOrId, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     foundPlayers.Add(player);
                 }


### PR DESCRIPTION
```csharp
"vlad-00003".IndexOf("vlad",StringComparison.OrdinalIgnoreCase) == 0
```
Pretty much self-explaining, it also worked that way before 7396a0968b52d261a59ca9eb1f2daed3452ee674