### PR TITLE
Allow BasePlayer.Find to find by players Net ID

### DIFF
--- a/src/RustCore.cs
+++ b/src/RustCore.cs
@@ -304,6 +304,11 @@ namespace Oxide.Game.Rust
                 {
                     return activePlayer;
                 }
+                
+                if (activePlayer.net?.connection != null && activePlayer.net.ID.Equals(nameOrIdOrIp))
+                {
+                    return activePlayer;
+                }
             }
             foreach (BasePlayer sleepingPlayer in BasePlayer.sleepingPlayerList)
             {


### PR DESCRIPTION
Allows for a more accurate and shorter param to pass.