### PR TITLE
Fix NRE for plugins without checking null (CanPushBoat)

### DIFF
--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -655,8 +655,13 @@ namespace Oxide.Game.Rust
         [HookMethod("OnVehiclePush")]
         private object OnVehiclePush(BaseVehicle vehicle, BasePlayer player)
         {
-            return Interface.Oxide.CallDeprecatedHook("CanPushBoat", "CanPushVehicle(BaseVehicle vehicle, BasePlayer player)",
+            if (vehicle is MotorRowboat)
+            {
+                return Interface.Oxide.CallDeprecatedHook("CanPushBoat", "CanPushVehicle(BaseVehicle vehicle, BasePlayer player)",
                 new System.DateTime(2021, 1, 1), player, vehicle as MotorRowboat);
+            }
+
+            return null;
         }
 
         #endregion Deprecated Hooks


### PR DESCRIPTION
NRE fix for old plugins that do not expect null in the second parameter.