### PR TITLE
Fix OnPlayerAttack [Projectile]

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -582,7 +582,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 1257,
+            "InjectionIndex": 1255,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l2",


### PR DESCRIPTION
Rust released an update ~9 hours ago (build id: 5346990), this began causing IL errors during patching
![ilerror](https://i.gyazo.com/5c24cbbc7cebab5ee332eaf175171abc.png)

This was causing players to disconnect due to RPC errors on creation of any projectile.

Pre fix:
![pre-fix](https://i.gyazo.com/12e953f6701932b9ab3638b25fb980d0.png)

Post fix:
![post-fix](https://i.gyazo.com/f717be19d1ab2b668015d9fab51ab4b0.png)