### PR TITLE
Add CanMoveVehicleModule hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12160,6 +12160,30 @@
             "BaseHookName": null,
             "HookCategory": "Resource"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 3,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "CanMoveVehicleModule",
+            "HookName": "CanMoveVehicleModule",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseVehicleModule",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanBeMovedNow",
+              "ReturnType": "System.Boolean",
+              "Parameters": []
+            },
+            "MSILHash": "DZp2MNTcx0dgvK12j2+b3DgPquu7Pt2GI3g1vYLhCd8=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
This hook allows overriding whether a vehicle module can be removed from a car at a lift.

I was thinking this might be an issue for performance since it's called in `VehicleFixedUpdate()`, but it seems to be only when the vehicle is in an editable location (on a car lift), and only at most once per second per module. If that's too often, I can alternatively expose `BaseVehicleModule.timeSinceItemLockRefresh` and override it to a big negative number in a plugin to prevent the game from overriding the locked state for a specific module after I've locked/unlocked it.