### PR TITLE
Add OnSwitchToggled hook for ElectricSwitch

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,32 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 14,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnSwitchToggled [ElectricSwitch]",
+            "HookName": "OnSwitchToggled",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ElectricSwitch",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "SVSwitch",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "WY7Pk1dKaALsdA07cLtVDLnBFGwAO7jOkUpU6l3rdXE=",
+            "BaseHookName": "OnSwitchToggle [ElectricSwitch]",
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
void OnSwitchToggled(ElectricSwitch switch, BasePlayer player)
```

This adds a post-hook variant of OnSwitchToggle called OnSwitchToggled that runs after the switch is toggled successfully. Various plugins using OnSwitchToggle should probably change to use OnSwitchToggled eventually.