### PR TITLE
Add OnTurretRotate hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,32 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 12,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnTurretRotate",
+            "HookName": "OnTurretRotate",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "AutoTurret",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "FlipAim",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "FUugUQq5lqODAUqd//LLeBNKU3HTX8C0yTciTHganjo=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnTurretRotate(AutoTurret turret, BasePlayer player)
```

Returning non-null prevents the default behavior. Planning to use this to rotate at a custom angle instead of 180 degrees.