### PR TITLE
Add OnItemLock and OnItemUnlock hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,138 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 6,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 6
+              },
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnItemLock"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object)"
+              },
+              {
+                "OpCode": "ldnull",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "beq_s",
+                "OpType": "Instruction",
+                "Operand": 6
+              },
+              {
+                "OpCode": "ret",
+                "OpType": "None",
+                "Operand": null
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnItemLock",
+            "HookName": "OnItemLock",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Item",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "LockUnlock",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "mey0N9WmT2k+EzGVoyZwBOhf3iSTLI4YglIQSNqrE84=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 14,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brtrue_s",
+                "OpType": "Instruction",
+                "Operand": 14
+              },
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnItemUnlock"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object)"
+              },
+              {
+                "OpCode": "ldnull",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "beq_s",
+                "OpType": "Instruction",
+                "Operand": 14
+              },
+              {
+                "OpCode": "ret",
+                "OpType": "None",
+                "Operand": null
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnItemUnlock",
+            "HookName": "OnItemUnlock",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Item",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "LockUnlock",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "mey0N9WmT2k+EzGVoyZwBOhf3iSTLI4YglIQSNqrE84=",
+            "BaseHookName": "OnItemLock",
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnItemLock(Item item)
```
```csharp
object OnItemUnlock(Item item)
```

Returning non-null will prevent the default behavior.

Decompiled code:

```csharp
public void LockUnlock(bool bNewState)
{
    if (this.HasFlag(Item.Flag.IsLocked) == bNewState)
    {
        return;
    }
    if (bNewState && Interface.CallHook("OnItemLock", this) != null)
    {
        return;
    }
    if (!bNewState && Interface.CallHook("OnItemUnlock", this) != null)
    {
        return;
    }
    this.SetFlag(Item.Flag.IsLocked, bNewState);
    this.MarkDirty();
}
```

This is intended to be used to prevent locking or unlocking a vehicle module item. The vehicle module can be obtained from the item with roughly `item.parent.entityOwner.GetModuleForItem(item)`.

It turns out whether an item is locked is just a visual indicator, so I additionally opened #235 to allow blocking or forcibly allowing a vehicle module to be moved.