### PR TITLE
Add OnVehicleModuleMove hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,33 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnVehicleModuleMove",
+            "HookName": "OnVehicleModuleMove",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseModularVehicle",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanMoveFrom",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer",
+                "Item"
+              ]
+            },
+            "MSILHash": "NaLlgvw7uiae7VmVJOZIGc0nHFeASEP/09a0F3I5hDI=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnVehicleModuleMove(ModularCar car, BasePlayer player, Item item)
```

Called when a player tries to move or drop a vehicle module item that's in a vehicle's inventory.

Note: Allowing both `true` and `false` return values is intentional to allow the use case of removing a module even when it has items in its storage container, as well as to prevent a module from being moved if it has entity attachments such as turrets.