### PR TITLE
Add MiniCopter OnEngineStartup hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,30 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnEngineStartup [MiniCopter]",
+            "HookName": "OnEngineStartup",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "MiniCopter",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "EngineStartup",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "8pAleyRavdKKmX08YZ8lXfAd+OKZTQJwDFGeYol1aCU=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Signature:
```csharp
object OnEngineStartup(MiniCopter minicopter)
```

Decompiled code:
```csharp
public void EngineStartup()
{
    if (Interface.CallHook("OnEngineStartup", this) == null && !Waterlogged())
    {
        Invoke(EngineOn, 5f);
        SetFlag(Flags.Reserved4, b: true);
    }
}
```

Edit: Not sure how long this is going to last given that FP is changing how engines work for cars and minicopters due to the introduction of work carts.