### PR TITLE
Add NPCTalking conversation hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,58 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 21,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this,v0,v1",
+            "HookTypeName": "Simple",
+            "Name": "OnConversationStart",
+            "HookName": "OnConversationStart",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCTalking",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Server_BeginTalking",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "QUI/yjiuka5+HpxnCJUVtD4SHMtf86dRJ3BpvKECMuM=",
+            "BaseHookName": null,
+            "HookCategory": "NPC"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 30,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this,v0,v3,v4",
+            "HookTypeName": "Simple",
+            "Name": "OnConversationResponse",
+            "HookName": "OnConversationResponse",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCTalking",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Server_ResponsePressed",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "/mHTS1fXcl926C8A/lINUtOxjIWf2WuGc2N2XmPvS9I=",
+            "BaseHookName": null,
+            "HookCategory": "NPC"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
### OnConversationStart

```csharp
object OnConversationStart(NPCTalking npcTalking, BasePlayer player, ConversationData conversationData)
```

This can be used to prevent a player from starting a conversation with an NPC. This could be used to show a custom UI at a vehicle vendor instead of using the default dialog which isn't very customizable (largely client-side). This was requested here: https://umod.org/community/rust/25685-hook-for-when-player-talks-to-vehicle-vendor

### OnConversationResponse

```csharp
object OnConversationResponse(NPCTalking npcTalking, BasePlayer player, ConversationData conversationData, ConversationData.ResponseNode responseNode)
```

This can be used to override what happens when the player chooses a particular response. For instance, I prototyped a plugin
where choosing the "I'd like to buy a minicopter" response automatically spawns it for free and advances to the "success" speech node, completely skipping the conversation node where they are prompted to pay.