### PR TITLE
Add OnLootEntityEnd hook for more types

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,58 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this",
+            "HookTypeName": "Simple",
+            "Name": "OnLootEntityEnd [ContainerIOEntity]",
+            "HookName": "OnLootEntityEnd",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ContainerIOEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerStoppedLooting",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "zFUzhb16/jKJ5mdchUmrBB9VWZ7c4HXJ44m0KsXYWrI=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this",
+            "HookTypeName": "Simple",
+            "Name": "OnLootEntityEnd [DroppedItemContainer]",
+            "HookName": "OnLootEntityEnd",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "DroppedItemContainer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerStoppedLooting",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "4M5ZbzcLJYQ5244IZ049BhdKYRHecOJCqCWijHb+MeI=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
void OnLootEntityEnd(BasePlayer player, ContainerIOEntity container)
```

```csharp
void OnLootEntityEnd(BasePlayer player, DroppedItemContainer container)
```

Requested here:
- https://umod.org/community/rust/25657-hook-onlootentityend-for-containerioentity
- https://umod.org/community/rust/25484-hook-request-in-droppeditemcontainer

Edit: I just realized someone already opened a PR for the DroppedItemContainer case which I missed (#231). I'm assuming that's implemented the same as in this PR but I haven't checked.