### PR TITLE
Add hooks for toggling hot air balloons

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,84 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnHotAirBalloonToggle",
+            "HookName": "OnHotAirBalloonToggle",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "HotAirBalloon",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "EngineSwitch",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "x7cfCfVJLzvL/ot/WPYBQI8MpdBgpW8acLm1AmVfzu8=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnHotAirBalloonToggled [on]",
+            "HookName": "OnHotAirBalloonToggled",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "HotAirBalloon",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "EngineSwitch",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "x7cfCfVJLzvL/ot/WPYBQI8MpdBgpW8acLm1AmVfzu8=",
+            "BaseHookName": "OnHotAirBalloonToggle",
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 39,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnHotAirBalloonToggled [off]",
+            "HookName": "OnHotAirBalloonToggled",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "HotAirBalloon",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "EngineSwitch",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "x7cfCfVJLzvL/ot/WPYBQI8MpdBgpW8acLm1AmVfzu8=",
+            "BaseHookName": "OnHotAirBalloonToggled [on]",
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnHotAirBalloonToggle(HotAirBalloon hab, BasePlayer player)
```
```csharp
void OnHotAirBalloonToggled(HotAirBalloon hab, BasePlayer player)
```

Decompiled code:
```csharp
public void EngineSwitch(RPCMessage msg)
{
    if (Interface.CallHook("OnHotAirBalloonToggle", this, msg.player) == null)
    {
        bool b = msg.read.Bit();
        SetFlag(Flags.On, b);
        if (IsOn())
        {
            Invoke(ScheduleOff, 60f);
            Interface.CallHook("OnHotAirBalloonToggled", this, msg.player);
        }
        else
        {
            CancelInvoke(ScheduleOff);
            Interface.CallHook("OnHotAirBalloonToggled", this, msg.player);
        }
    }
}
```

I wrote it this way (duplicated the hook call) because I couldn't easily move the hook call to the end of the inside of the `if {}` block.