### PR TITLE
Add hook for modular car locks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,30 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnCanCarHaveLock",
+            "HookName": "OnCanCarHaveLock",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ModularCarLock",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanHaveALock",
+              "ReturnType": "System.Boolean",
+              "Parameters": []
+            },
+            "MSILHash": "9dP0JIfzRGx5637tRNiFOzhHNkhW3jQfjE7yqojwZ1k=",
+            "BaseHookName": null,
+            "HookCategory": "Vehicle"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnCanCarHaveLock(ModularCarLock modularCarLock)
```

The primary use I have for this is to prevent cars from having native locks added to them. This hook is called on fixed update for cars that are currently on a lift in order to determine the lock state which affects client UIs. When this hook returns false, the client UIs will not show any indication that it can have a lock, allowing plugins to use up that UI real estate for other things, such as buttons that allow adding deployable key locks and code locks.

I'm not attached to the ability to allow a lock on a car that doesn't have driver mount points, so if you want to change this to a block-only hook, that would be okay with me.