### PR TITLE
Add hooks for selecting vehicle modules

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,58 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 37,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, v0, v2",
+            "HookTypeName": "Simple",
+            "Name": "OnVehicleModuleSelect",
+            "HookName": "OnVehicleModuleSelect",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ModularCarGarage",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_SelectedLootItem",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "lWVHFE9tidj4At4ZQjXH3qbpXAqhUGqiHmB8hsjEyBo=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 26,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, v0",
+            "HookTypeName": "Simple",
+            "Name": "OnVehicleModuleDeselected",
+            "HookName": "OnVehicleModuleDeselected",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ModularCarGarage",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_DeselectedLootItem",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "vu7lOJv/y+cUOlPA4HGFG23WH+e+IvdnzSTE8CaOR3U=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
These hooks intercept the RPC calls when a player selects or deselects a vehicle module that's in the inventory of a car they are editing at a lift. The game normally uses this to show/hide a storage container for storage/engine modules.

### OnVehicleModuleSelect
```csharp
object OnVehicleModuleSelect(ModularCarGarage carLift, BasePlayer player, Item item)
```

The *Select hook can be used to cancel showing the player the module's storage inventory. That's a simple way to prevent players from taking out the items which they can otherwise do even when the storage container is locked, though other hooks can already block this on an individual item basis. This hook can also be used to perform side effects such as to show a UI button which will add an auto turret to the module. I originally added a *Selected post hook for the latter use case, but it makes sense to use the pre hook for most cases since the user does in fact have the item selected client-side even if a plugin blocked this hook. A post hook can always be added in the future if useful.

### OnVehicleModuleDeselected
```csharp
void OnVehicleModuleDeselected(ModularCarGarage carLift, BasePlayer player)
```

The *Deselect hook is to allow for cleanup of side effects introduced by the *Select hook, such as to destroy custom per-module UIs. UI plugins will need to accompany this with other hooks to make sure UIs are destroyed when the player stops looting the car since this hook isn't called in that case.