### PR TITLE
Add hook for assigning car modules

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12602,6 +12602,30 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 11,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnCarModulesAssign",
+            "HookName": "OnCarModulesAssign",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ModularCar",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "SpawnPreassignedModules",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "274yT4IJ3fuxLHwhPNn2uaxwCSO8438cQhc49fPrshU=",
+            "BaseHookName": null,
+            "HookCategory": "Vehicle"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnCarModulesAssign(ModularCar car)
```

Overriding this by returning non-null will allow plugins to replace the default module presets with custom ones.