### PR TITLE
Include Rust.Plaform.Common.dll in project

### DIFF
--- a/src/Oxide.Rust.csproj
+++ b/src/Oxide.Rust.csproj
@@ -41,6 +41,7 @@
     <Reference Include="NewAssembly" />
     <Reference Include="Rust.Data" />
     <Reference Include="Rust.Global" />
+    <Reference Include="Rust.Platform.Common" />
     <Reference Include="System" />
     <Reference Include="UnityEngine" />
     <Reference Include="UnityEngine.CoreModule" />


### PR DESCRIPTION
This is to fix a hook that is not applying correctly.

Failed to apply hook IOnPlayerBanned [Publisher/VAC]
Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'Rust.Platform.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'