### PR TITLE
Removing OnEntityKill [BradleyAPC] as it's obsolete

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -9612,32 +9612,6 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 4,
-            "ReturnBehavior": 1,
-            "ArgumentBehavior": 1,
-            "ArgumentString": null,
-            "HookTypeName": "Simple",
-            "Name": "OnEntityKill [BradleyAPC]",
-            "HookName": "OnEntityKill",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "BradleyAPC",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "OnKilled",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "HitInfo"
-              ]
-            },
-            "MSILHash": "PN6KcgmzwCeNe3sUvJui8jmKMSB5xmX9/Ep+fvxptUg=",
-            "BaseHookName": null,
-            "HookCategory": "Entity"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
             "InjectionIndex": 8,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,


### PR DESCRIPTION
I'm not sure why it was created in the first place, but now - it calls OnEntityKill twice on the bradley
BradleyAPC.OnKilled calls BaseCombatEntity.OnKilled, that calls BaseNetworkable.Kill where OnEntityKill already presented.

This way the hook would be called twice - before actuall object being destroyed and after: 
![image](https://user-images.githubusercontent.com/31519848/95227711-1c72a200-0807-11eb-925f-cf8099c15d63.png)
![image](https://user-images.githubusercontent.com/31519848/95227735-23011980-0807-11eb-926c-223dfdb29380.png)
![image](https://user-images.githubusercontent.com/31519848/95227753-28f6fa80-0807-11eb-97ac-a436d6b0ea6d.png)
![image](https://user-images.githubusercontent.com/31519848/95227770-2e544500-0807-11eb-9870-1c0614925eb0.png)
