### PR TITLE
ItemModCookable hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -13056,6 +13056,60 @@
             "BaseHookName": "OnCounterModeToggle",
             "HookCategory": "Entity"
           }
+        },		
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0,a1",
+            "HookTypeName": "Simple",
+            "Name": "OnItemCook",
+            "HookName": "OnItemCook",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ItemModCookable/<>c__DisplayClass7_0",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 3,
+              "Name": "<OnItemCreated>b__0",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Item",
+                "System.Single"
+              ]
+            },
+            "MSILHash": "3oIDJHL3h1GJEhGG87KHlx5hmHmh4mA2QanbUZQE6NA=",
+            "BaseHookName": "OnItemCooked",
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 83,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0,a1",
+            "HookTypeName": "Simple",
+            "Name": "OnItemCooked",
+            "HookName": "OnItemCooked",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ItemModCookable/<>c__DisplayClass7_0",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 3,
+              "Name": "<OnItemCreated>b__0",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Item",
+                "System.Single"
+              ]
+            },
+            "MSILHash": "3oIDJHL3h1GJEhGG87KHlx5hmHmh4mA2QanbUZQE6NA=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
private object OnItemCook(Item item, float delta) - being called at the start of the cycle. Usefull to prevent some items from being cooked in that specific furnace
private object OnItemCooked(Item item, float delta) - being called right before spawning becomeOnCooked, usefull to change the result of cooking

Both hooks are usefull in the situation where you need to modify either speed (canceling cycle in the first hook, doing everything in the plugin) or outcome (creating items with skin as a result of burning)
The only way to do this now is to re-create cooking functions in the plugin, and makes it impossible to have 2 plugins doing simular things at once