### PR TITLE
Fix hooks for selecting vehicle modules

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -13510,10 +13510,10 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 66,
+            "InjectionIndex": 70,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "l5, this, l0",
+            "ArgumentString": "l2, this, l0",
             "HookTypeName": "Simple",
             "Name": "OnVehicleModuleSelected",
             "HookName": "OnVehicleModuleSelected",
@@ -13536,101 +13536,42 @@
         {
           "Type": "Modify",
           "Hook": {
-            "InjectionIndex": 26,
-            "RemoveCount": 0,
+            "InjectionIndex": 30,
+            "RemoveCount": 1,
             "Instructions": [
-              {
-                "OpCode": "ldarg_1",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "ldfld",
-                "OpType": "Field",
-                "Operand": "Assembly-CSharp|BaseEntity/RPCMessage|read"
-              },
-              {
-                "OpCode": "callvirt",
-                "OpType": "Method",
-                "Operand": "Facepunch.Network|Network.NetRead|UInt32"
-              },
-              {
-                "OpCode": "stloc_1",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "ldarg_0",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "call",
-                "OpType": "Method",
-                "Operand": "Assembly-CSharp|ModularCarGarage|get_carOccupant"
-              },
-              {
-                "OpCode": "ldloc_1",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "callvirt",
-                "OpType": "Method",
-                "Operand": "Assembly-CSharp|BaseModularVehicle|GetVehicleItem(System.UInt32)"
-              },
-              {
-                "OpCode": "stloc_2",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "ldloc_2",
-                "OpType": "None",
-                "Operand": null
-              },
               {
                 "OpCode": "brfalse_s",
                 "OpType": "Instruction",
-                "Operand": 1041
-              },
-              {
-                "OpCode": "ldstr",
-                "OpType": "String",
-                "Operand": "OnVehicleModuleDeselected"
-              },
-              {
-                "OpCode": "ldloc_2",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "ldarg_0",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "ldloc_0",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "call",
-                "OpType": "Method",
-                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object,System.Object)"
-              },
-              {
-                "OpCode": "pop",
-                "OpType": "None",
-                "Operand": null
-              },
-              {
-                "OpCode": "ret",
-                "OpType": "None",
-                "Operand": null
+                "Operand": 76
               }
             ],
             "HookTypeName": "Modify",
+            "Name": "OnVehicleModuleSelected [patch]",
+            "HookName": "OnVehicleModuleSelected [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ModularCarGarage",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_SelectedLootItem",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "lWVHFE9tidj4At4ZQjXH3qbpXAqhUGqiHmB8hsjEyBo=",
+            "BaseHookName": "OnVehicleModuleSelected",
+            "HookCategory": "Vehicle"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 26,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
             "Name": "OnVehicleModuleDeselected",
             "HookName": "OnVehicleModuleDeselected",
             "AssemblyName": "Assembly-CSharp.dll",


### PR DESCRIPTION
Removed Item argument to `OnVehicleModuleDeselected` because the RPC message doesn't seem to contain the information required to get it anyway.

Changed `OnVehicleModuleSelected` to pass an `Item` instead of a `BaseVehicleModule` to be consistent with the `OnVehicleModuleSelect` hook (plugins can get the module if they want anyway). Also moved the hook call to a different line so that it's called for all module types instead of just for storage modules.