### PR TITLE
Add OnVehicleModuleMove hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -13648,6 +13648,73 @@
             "BaseHookName": null,
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 8,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnVehicleModuleMove"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldloc_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 8
+              },
+              {
+                "OpCode": "ldc_i4_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ret",
+                "OpType": "None",
+                "Operand": null
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnVehicleModuleMove",
+            "HookName": "OnVehicleModuleMove",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseModularVehicle",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanMoveFrom",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer",
+                "Item"
+              ]
+            },
+            "MSILHash": "NaLlgvw7uiae7VmVJOZIGc0nHFeASEP/09a0F3I5hDI=",
+            "BaseHookName": null,
+            "HookCategory": "Vehicle"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Following up for #235 since it was reverted.

```csharp
object OnVehicleModuleMove(ModularCar car, BaseVehicleModule module, BasePlayer player)
```

- Called when a player tries to move or drop a vehicle module item that's in a vehicle's inventory.
- Returning non-null cancels the default behavior (does not allow moving the module item)

This is different from #235 in that hook subscribers have no way to cause the hooked method to return true, only false.