### PR TITLE
Add hooks for claiming horses

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14287,6 +14287,58 @@
             "BaseHookName": "OnExperimentEnd",
             "HookCategory": "Player"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 8,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnRidableAnimalClaim",
+            "HookName": "OnRidableAnimalClaim",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseRidableAnimal",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_Claim",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "7Mx+AMadbNc1xkT90uhKbYwSoEB1kh97KkqLTMKRSs0=",
+            "BaseHookName": null,
+            "HookCategory": "Vehicle"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 39,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnRidableAnimalClaimed",
+            "HookName": "OnRidableAnimalClaimed",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseRidableAnimal",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_Claim",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "7Mx+AMadbNc1xkT90uhKbYwSoEB1kh97KkqLTMKRSs0=",
+            "BaseHookName": "OnRidableAnimalClaim",
+            "HookCategory": "Vehicle"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Resubmitting #257 to develop branch, with one change: Moved OnRidableAnimalClaim to before the `IsForSale()` check.

```csharp
object OnRidableAnimalClaim(BaseRidableAnimal animal, BasePlayer player)
```
```csharp
void OnRidableAnimalClaimed(BaseRidableAnimal animal, BasePlayer player)
```

Decompiled code of the method being hooked:
```csharp
[BaseEntity.RPC_Server, BaseEntity.RPC_Server.IsVisible(3f)]
public void RPC_Claim(BaseEntity.RPCMessage msg)
{
    BasePlayer player = msg.player;
    if (player == null)
    {
        return;
    }
    if (Interface.CallHook("OnRidableAnimalClaim", this, player) != null)
    {
        return;
    }
    if (!this.IsForSale())
    {
        return;
    }
    Item item = this.GetPurchaseToken(player);
    if (item == null)
    {
        return;
    }
    item.UseItem(1);
    base.SetFlag(BaseEntity.Flags.Reserved2, false, false, true);
    this.AttemptMount(player, false);
    Interface.CallHook("OnRidableAnimalClaimed", this, player);
}
```

Tested and working.