### PR TITLE
Add CanSwapToSeat hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14247,6 +14247,58 @@
             "BaseHookName": null,
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this",
+            "HookTypeName": "Simple",
+            "Name": "CanSwapToSeat [BaseMountable]",
+            "HookName": "CanSwapToSeat",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseMountable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanSwapToThis",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "P3Mx+v3adUs95vU27ANKY5mvZxgLUs14zJrrTfI5vlw=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this",
+            "HookTypeName": "Simple",
+            "Name": "CanSwapToSeat [ModularCarSeat]",
+            "HookName": "CanSwapToSeat",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ModularCarSeat",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanSwapToThis",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "8tR5osczoxJH8EHX6XduMEEmlAAoC6tL4WNM+H4Qd0g=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Resubmitting #258 to develop branch with changes. Now using traditional Can hook since it seems like the best fit even though new Can hooks haven't been accepted recently.

```csharp
object CanSwapToSeat(BasePlayer player, BaseMountable mountable)
```

- Returning a boolean will override the default behavior to return that value.
- Returning null will result in the default behavior

This is intended to be used to prevent swapping seats from a taxi module to a non-taxi module when the non-taxi seats are locked via a plugin. It can technically already be blocked, but this results in the player being partially dismounted while in the car, so instead of simply blocking mounting, this hook will be used to consider locked modules as ineligible for being swapped to so that the game can find a more appropriate seat for the player (another taxi module seat).

### Decompiled code of method being hooked [BaseMountable]
```csharp
public virtual bool CanSwapToThis(BasePlayer player)
{
    object returnvar = Interface.CallHook("CanSwapToSeat", player, this);
    return !(returnvar is bool) || (bool)returnvar;
}
```

### Decompiled code of method being hooked [ModularCarSeat]
```csharp
public override bool CanSwapToThis(BasePlayer player)
{
    object returnvar = Interface.CallHook("CanSwapToSeat", player, this);
    if (returnvar is bool)
    {
        return (bool)returnvar;
    }
    if (this.associatedSeatingModule.DoorsAreLockable)
    {
        ModularCar modularCar = this.associatedSeatingModule.Vehicle as ModularCar;
        if (modularCar != null)
        {
            return modularCar.PlayerCanOpenThis(player, ModularCarLock.LockType.Door);
        }
    }
    return true;
}
```