### PR TITLE
Add networking hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -13970,32 +13970,6 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 17,
-            "ReturnBehavior": 0,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, a0",
-            "HookTypeName": "Simple",
-            "Name": "OnElevatorSaved",
-            "HookName": "OnElevatorSaved",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "Elevator",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "Save",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseNetworkable/SaveInfo"
-              ]
-            },
-            "MSILHash": "qsQ9/jyxnYIJY79QA1Ei4ZdqFNs3AyMAM8evploGvKU=",
-            "BaseHookName": null,
-            "HookCategory": "Entity"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
@@ -14401,6 +14375,138 @@
             },
             "MSILHash": "EPpjxhDmTMcxrZUN2ASehLW+b1X/7HRX0wD/nNqbTV4=",
             "BaseHookName": "OnPhoneNameUpdate",
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 26,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a1",
+            "HookTypeName": "Simple",
+            "Name": "IOnEntitySaved",
+            "HookName": "IOnEntitySaved",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseNetworkable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "ToStream",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.IO.Stream",
+                "BaseNetworkable/SaveInfo"
+              ]
+            },
+            "MSILHash": "4osFyUWXrAggoRzs7vhPacYm8tF3fwewKVHFvu8Joy4=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnEntitySnapshot",
+            "HookName": "OnEntitySnapshot",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseNetworkable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 1,
+              "Name": "SendAsSnapshot",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Network.Connection",
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "6bB73ajskchotLYKe+TKZ/cqWB0W2xf4vsuFkgClTV4=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this.net.connection",
+            "HookTypeName": "Simple",
+            "Name": "OnEntitySnapshot",
+            "HookName": "OnEntitySnapshot",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "SendEntitySnapshot",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseNetworkable"
+              ]
+            },
+            "MSILHash": "+rCpTPYV2zRpoyj++Wbxa+MufcfLVfJpB+MkVULPg94=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnNetworkGroupEntered",
+            "HookName": "OnNetworkGroupEntered",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseNetworkable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnNetworkGroupEnter",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Network.Visibility.Group"
+              ]
+            },
+            "MSILHash": "+u2GCtSHTDWu7iqcjcFKh98FNKhbrQfPRx+LI73xrGk=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnNetworkGroupLeft",
+            "HookName": "OnNetworkGroupLeft",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseNetworkable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnNetworkGroupLeave",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Network.Visibility.Group"
+              ]
+            },
+            "MSILHash": "+u2GCtSHTDWu7iqcjcFKh98FNKhbrQfPRx+LI73xrGk=",
+            "BaseHookName": null,
             "HookCategory": "Entity"
           }
         }
@@ -27410,6 +27516,27 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BaseNetworkable::TerminateOnClient",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseNetworkable",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "TerminateOnClient",
+            "FullTypeName": "System.Void",
+            "Parameters": [
+              "BaseNetworkable/DestroyMode"
+            ]
+          },
+          "MSILHash": "xUFW++B0bRttK9P2wRgCl3fZzvSuTjKwO9NTKkdqCRA="
         }
       ],
       "Fields": [

--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -157,6 +157,24 @@ namespace Oxide.Game.Rust
             return null;
         }
 
+        /// <summary>
+        /// Called after a BaseNetworkable has been saved into a ProtoBuf object that is about to
+        /// be serialized for a network connection or cache
+        /// </summary>
+        /// <param name="baseNetworkable"></param>
+        /// <param name="saveInfo"></param>
+        [HookMethod("IOnEntitySaved")]
+        private void IOnEntitySaved(BaseNetworkable baseNetworkable, BaseNetworkable.SaveInfo saveInfo)
+        {
+            // Only call when saving for the network since we don't expect plugins to want to intercept saving to disk
+            if (!serverInitialized || saveInfo.forConnection == null)
+            {
+                return;
+            }
+
+            Interface.CallHook("OnEntitySaved", baseNetworkable, saveInfo);
+        }
+
         #endregion Entity Hooks
 
         #region Item Hooks
@@ -689,6 +707,13 @@ namespace Oxide.Game.Rust
             }
 
             return null;
+        }
+
+        [HookMethod("OnEntitySaved")]
+        private void OnEntitySaved(Elevator elevator, BaseNetworkable.SaveInfo saveInfo)
+        {
+            Interface.Oxide.CallDeprecatedHook("OnElevatorSaved", "OnEntitySaved(Elevator elevator, BaseNetworkable.SaveInfo saveInfo)",
+                new System.DateTime(2021, 3, 1), elevator, saveInfo);
         }
 
         #endregion Deprecated Hooks


### PR DESCRIPTION
## Summary

- Add OnEntitySaved(BaseNetworkable, SaveInfo)
- Add OnEntitySnapshot(BaseNetworkable, Connection)
- Add OnNetworkGroupEntered(BaseNetworkable, Group)
- Add OnNetworkGroupLeft(BaseNetworkable, Group)
- Deprecate OnElevatorSaved(Elevator, SaveInfo)
- Expose BaseNetworkable.TerminateOnClient(DestroyMode) as public

## Hooks

### OnEntitySaved(BaseNetworkable, BaseNetworkable.SaveInfo)

- Called when an entity has been saved to a Protobuf object before it is serialized to a network stream
- No return behavior
- Not called before saving to disk because probably not needed

Example plugins:
- [BetterElevators](https://umod.org/plugins/better-elevators)
- (Upcoming) [UpkeepDisplayFix](https://github.com/WheteThunger/UpkeepDisplayFix)

Decompiled code of hooked method:
```csharp
// BaseNetworkable
private void ToStream(Stream stream, global::BaseNetworkable.SaveInfo saveInfo)
{
    using (saveInfo.msg = Pool.Get<Entity>())
    {
        this.Save(saveInfo);
        if (saveInfo.msg.baseEntity == null)
        {
            Debug.LogError(this + ": ToStream - no BaseEntity!?");
        }
        if (saveInfo.msg.baseNetworkable == null)
        {
            Debug.LogError(this + ": ToStream - no baseNetworkable!?");
        }
        Interface.CallHook("IOnEntitySaved", this, saveInfo);
        saveInfo.msg.ToProto(stream);
        this.PostSave(saveInfo);
    }
}

```

### OnEntitySnapshot(BaseNetworkable, Connection)

- Called when an entity snapshot is about to be sent to a client connection
- Returning non-null cancels default behavior (does not send the snapshot)

Example plugins:
- (Upcoming) [ParentedEntityRenderFix](https://github.com/WheteThunger/ParentedEntityRenderFix)
  - Uses OnEntitySnapshot, OnNetworkGroupEntered, OnNetworkGroupLeft

Decompiled code of hooked methods:
```csharp
// BaseNetworkable
protected void SendAsSnapshot(Connection connection, bool justCreated = false)
{
    if (Interface.CallHook("OnEntitySnapshot", this, connection) != null)
    {
        return;
    }
    ...
}
```

```csharp
// BasePlayer
private void SendEntitySnapshot(BaseNetworkable ent)
{
    if (Interface.CallHook("OnEntitySnapshot", ent, this.net.connection) != null)
    {
        return;
    }
    ...
}
```

### OnNetworkGroupEntered(BaseNetworkable, Group)

- Called when a player subscribes to a network group
- No return behavior

Possible alternative name: `OnNetworkGroupSubscribed`

Decompiled code of hooked method:
```csharp
// BaseNetworkable
public virtual void OnNetworkGroupEnter(Group group)
{
    Interface.CallHook("OnNetworkGroupEntered", this, group);
}
```

### OnNetworkGroupLeft(BaseNetworkable, Group)

- Called when a player subscribes to a network group
- No return behavior

Possible alternative name: `OnNetworkGroupUnsubscribed`

Decompiled code of hooked method:
```csharp
// BaseNetworkable
public virtual void OnNetworkGroupLeave(Group group)
{
    Interface.CallHook("OnNetworkGroupLeft", this, group);
}
```