### PR TITLE
Add OnIORefCleared hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14626,6 +14626,69 @@
             "BaseHookName": "OnFuelConsume",
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|IOEntity/IORef|ioEnt"
+              },
+              {
+                "OpCode": "stloc_0",
+                "OpType": "None",
+                "Operand": null
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnIORefCleared [patch]",
+            "HookName": "OnIORefCleared [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "IOEntity/IORef",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Clear",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "PgdLt2KPMkooci/pBv8pJIKmyVMsEkxB0WKZXLpcKWg=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 10,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnIORefCleared",
+            "HookName": "OnIORefCleared",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "IOEntity/IORef",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Clear",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "PgdLt2KPMkooci/pBv8pJIKmyVMsEkxB0WKZXLpcKWg=",
+            "BaseHookName": "OnIORefCleared [patch]",
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
void OnIORefCleared(IOEntity.IORef ioRef, IOEntity ioEntity)
```

Called when a wire has been cleared from an IO entity (usually two entities at once, so this will be called twice). This can happen a number of different ways, such as when cleared via a wire tool, or when either entity is killed or moves.

The following example plugin uses this hook to detect when a wire is cleared, in order to send power in its place. Ideally the hook could provide more information but it would have to be implemented in several others places, and this was sufficient for my use case.
https://github.com/WheteThunger/PowerlessElectronics/blob/master/PowerlessElectronics.cs

Decompiled code of method being hooked:

```csharp
public void Clear()
{
    global::IOEntity OxideGen_0 = this.ioEnt;
    this.ioEnt = null;
    this.entityRef.Set(null);
    Interface.CallHook("OnIORefCleared", this, OxideGen_0);
}
```
