### PR TITLE
Add tech tree hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14626,6 +14626,60 @@
             "BaseHookName": "OnFuelConsume",
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, a1, this",
+            "HookTypeName": "Simple",
+            "Name": "CanPlayerUnlock",
+            "HookName": "CanPlayerUnlock",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TechTreeData",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerCanUnlock",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer",
+                "TechTreeData/NodeInstance"
+              ]
+            },
+            "MSILHash": "YU5WD6A6IKJ+VI8LwSmCkfJ6grEAaIfk3da7g5+TgMI=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, a1, this",
+            "HookTypeName": "Simple",
+            "Name": "OnUnlockPathCheck",
+            "HookName": "OnUnlockPathCheck",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TechTreeData",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerHasPathForUnlock",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer",
+                "TechTreeData/NodeInstance"
+              ]
+            },
+            "MSILHash": "HSv8gCPuE5vz7UGz+M0mOtg+w/aHizacM5rzOahKBn8=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object CanPlayerUnlock(BasePlayer player, TechTreeData.NodeInstance node, TechTreeData techTree)
```

- Called when a player tries to unlock an item in a tech tree (even when the button says "no path")
- Returning true or false will allow or disallow the unlock, null will result in the default behavior
- Useful for disallowing an item from being unlocked, such as globally or based on permissions

```csharp
object OnUnlockPathCheck(BasePlayer player, TechTreeData.NodeInstance node, TechTreeData techTree)
```

- Called after the `CanPlayerUnlock` check, when determining if the player has unlocked the prerequisite items
- Returning true or false will allow or disallow the unlock, null will result in the default behavior
- Useful for customizing prerequisites without conflicting with CanPlayerUnlock
