### PR TITLE
Add OnEntityFlagsNetworkUpdate hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14896,6 +14896,30 @@
             "BaseHookName": "OnIORefCleared [patch]",
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnEntityFlagsNetworkUpdate",
+            "HookName": "OnEntityFlagsNetworkUpdate",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 1,
+              "Name": "SendNetworkUpdate_Flags",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "1JpW7U80IMTBb8tDqdYJS6x75INmaXdJ6aP6XJjsg74=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [
@@ -28367,6 +28391,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BaseNetworkable::GetSubscribers",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseNetworkable",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              1
+            ],
+            "Name": "GetSubscribers",
+            "FullTypeName": "System.Collections.Generic.List`1<Network.Connection>",
+            "Parameters": []
+          },
+          "MSILHash": "DYKTp/ghYQgeINCkvR1MpkAQdk8Gtg1gEClR9TdJWgU="
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14626,6 +14626,69 @@
             "BaseHookName": "OnFuelConsume",
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|IOEntity/IORef|ioEnt"
+              },
+              {
+                "OpCode": "stloc_0",
+                "OpType": "None",
+                "Operand": null
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnIORefCleared [patch]",
+            "HookName": "OnIORefCleared [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "IOEntity/IORef",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Clear",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "PgdLt2KPMkooci/pBv8pJIKmyVMsEkxB0WKZXLpcKWg=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 10,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnIORefCleared",
+            "HookName": "OnIORefCleared",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "IOEntity/IORef",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Clear",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "PgdLt2KPMkooci/pBv8pJIKmyVMsEkxB0WKZXLpcKWg=",
+            "BaseHookName": "OnIORefCleared [patch]",
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14628,6 +14628,60 @@
           }
         },
         {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, a1, this",
+            "HookTypeName": "Simple",
+            "Name": "CanPlayerUnlock",
+            "HookName": "CanPlayerUnlock",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TechTreeData",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerCanUnlock",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer",
+                "TechTreeData/NodeInstance"
+              ]
+            },
+            "MSILHash": "YU5WD6A6IKJ+VI8LwSmCkfJ6grEAaIfk3da7g5+TgMI=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, a1, this",
+            "HookTypeName": "Simple",
+            "Name": "OnUnlockPathCheck",
+            "HookName": "OnUnlockPathCheck",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TechTreeData",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerHasPathForUnlock",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer",
+                "TechTreeData/NodeInstance"
+              ]
+            },
+            "MSILHash": "HSv8gCPuE5vz7UGz+M0mOtg+w/aHizacM5rzOahKBn8=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
           "Type": "Modify",
           "Hook": {
             "InjectionIndex": 0,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -27967,6 +27967,139 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "NeonSign::animationSpeed",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NeonSign",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "animationSpeed",
+            "FullTypeName": "System.Single NeonSign::animationSpeed",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "NeonSign::currentFrame",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NeonSign",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "currentFrame",
+            "FullTypeName": "System.Int32 NeonSign::currentFrame",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "NeonSign::frameLighting",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NeonSign",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "frameLighting",
+            "FullTypeName": "System.Collections.Generic.List`1<ProtoBuf.NeonSign/Lights> NeonSign::frameLighting",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "NeonSign::isAnimating",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NeonSign",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "isAnimating",
+            "FullTypeName": "System.Boolean NeonSign::isAnimating",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "NeonSign::animationLoopAction",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NeonSign",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "animationLoopAction",
+            "FullTypeName": "System.Action NeonSign::animationLoopAction",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "NeonSign::EnsureInitialized",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NeonSign",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "EnsureInitialized",
+            "FullTypeName": "System.Void",
+            "Parameters": []
+          },
+          "MSILHash": "liP9ceb12JWyYn6Nzv3DurkoCcOyBdHrx0tQ/+nfiMY="
+        },
+        {
+          "Name": "Signage::EnsureInitialized",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "Signage",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "EnsureInitialized",
+            "FullTypeName": "System.Void",
+            "Parameters": []
+          },
+          "MSILHash": "i4D7EZTe/CAzRKYfVEoNvdFHXDzcDvruadHdtziyF1g="
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -14630,6 +14630,159 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 3,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnFuelAmountCheck",
+            "HookName": "OnFuelAmountCheck",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "EntityFuelSystem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GetFuelAmount",
+              "ReturnType": "System.Int32",
+              "Parameters": []
+            },
+            "MSILHash": "sp8yuC6cMzp6Fp6SZkhNIyMqoNPUUBa1lcXXyO5Xfms=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 3,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnFuelItemCheck",
+            "HookName": "OnFuelItemCheck",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "EntityFuelSystem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GetFuelItem",
+              "ReturnType": "Item",
+              "Parameters": []
+            },
+            "MSILHash": "tEDVXIr7sssNaFWY8IXnxOqtiiSJ+Zao18Zo66sJKKo=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnFuelCheck",
+            "HookName": "OnFuelCheck",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "EntityFuelSystem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "HasFuel",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "d/3tSEyHXtJf3UU5zfzOH/G6Qt5DpFofZzkO3wJAyf8=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 3,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnFuelRangeCheck",
+            "HookName": "OnFuelRangeCheck",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "EntityFuelSystem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "IsInFuelInteractionRange",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "QGEaTqGFXnU/vXUaaYbxbNLdsJDsQnI+IYHeydV7S3Y=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnFuelLoot",
+            "HookName": "OnFuelLoot",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "EntityFuelSystem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "LootFuel",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "PAn9DWSp3QRJlURRWNDEcZrQLDlDFU+4mf+gy4hYvic=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 3,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnFuelUse",
+            "HookName": "OnFuelUse",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "EntityFuelSystem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "TryUseFuel",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "System.Single",
+                "System.Single"
+              ]
+            },
+            "MSILHash": "lXRMZRU6x7961KKvvXbcJgXVv6RX/joglZlLwyTq2aw=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
@@ -28100,6 +28253,120 @@
             "Parameters": []
           },
           "MSILHash": "i4D7EZTe/CAzRKYfVEoNvdFHXDzcDvruadHdtziyF1g="
+        },
+        {
+          "Name": "EntityFuelSystem::pendingFuel",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "pendingFuel",
+            "FullTypeName": "System.Single EntityFuelSystem::pendingFuel",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "EntityFuelSystem::cachedHasFuel",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedHasFuel",
+            "FullTypeName": "System.Boolean EntityFuelSystem::cachedHasFuel",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "EntityFuelSystem",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 3,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              2
+            ],
+            "Name": "EntityFuelSystem",
+            "FullTypeName": "EntityFuelSystem",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "EntityFuelSystem::isServer",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "isServer",
+            "FullTypeName": "System.Boolean EntityFuelSystem::isServer",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "EntityFuelSystem::owner",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "owner",
+            "FullTypeName": "BaseEntity EntityFuelSystem::owner",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "EntityFuelSystem::nextFuelCheckTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextFuelCheckTime",
+            "FullTypeName": "System.Single EntityFuelSystem::nextFuelCheckTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
### OnEntityFlagsNetworkUpdate

- Called when an entity is sending a network update with just BaseEntity flags
- Returning a non-null value overrides default behavior

```csharp
object OnEntityFlagsNetworkUpdate(BaseEntity entity)
{
    Puts("OnEntityFlagsNetworkUpdate works!");
    return null;
}
```

Example in https://github.com/WheteThunger/LootablePoweredTurrets

Decompiled code of method being hooked:

```csharp
protected void SendNetworkUpdate_Flags()
{
    if (Rust.Application.isLoading || Rust.Application.isLoadingSave || base.IsDestroyed || net == null || !isSpawned)
    {
        return;
    }
    using (TimeWarning.New("SendNetworkUpdate_Flags"))
    {
        LogEntry(LogEntryType.Network, 2, "SendNetworkUpdate_Flags");
        if (Interface.CallHook("OnEntityFlagsNetworkUpdate", this) == null)
        {
            List<Connection> subscribers = GetSubscribers();
            if (subscribers != null && subscribers.Count > 0 && Network.Net.sv.write.Start())
            {
                Network.Net.sv.write.PacketID(Message.Type.EntityFlags);
                Network.Net.sv.write.EntityID(net.ID);
                Network.Net.sv.write.Int32((int)flags);
                SendInfo info = new SendInfo(subscribers);
                Network.Net.sv.write.Send(info);
            }
            OnSendNetworkUpdateEx.SendOnSendNetworkUpdate(base.gameObject, this);
        }
    }
}
```