### PR TITLE
Removing static modifier from EntityComponent.baseEntity

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -28981,8 +28981,7 @@
           "TypeName": "EntityComponent`1",
           "Type": 2,
           "TargetExposure": [
-            2,
-            4
+            2
           ],
           "Flagged": false,
           "Signature": {


### PR DESCRIPTION
I really don't know why we have static modifier for a non-static getter in the class

I also don't know why this doesn't cause any other problems, but the thing is - I have a plugin that contains custom class inherited from EntityComponent. Now every time I'm trying to use it I get IL error due to the fact that baseEntity can not be used in non-static context... while it is non-static property

![image](https://user-images.githubusercontent.com/31519848/103946015-2201c000-5147-11eb-92d1-1b6388a4270e.png)
