### PR TITLE
Add missing expiry arguments for user banned hooks

### DIFF
--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -269,15 +269,16 @@ namespace Oxide.Game.Rust
         /// <param name="group"></param>
         /// <param name="name"></param>
         /// <param name="reason"></param>
+        /// <param name="expiry"></param>
         [HookMethod("IOnServerUsersSet")]
-        private void IOnServerUsersSet(ulong steamId, ServerUsers.UserGroup group, string playerName, string reason)
+        private void IOnServerUsersSet(ulong steamId, ServerUsers.UserGroup group, string playerName, string reason, ulong expiry)
         {
             if (serverInitialized && group == ServerUsers.UserGroup.Banned)
             {
                 string playerId = steamId.ToString();
                 IPlayer player = Covalence.PlayerManager.FindPlayerById(playerId);
-                Interface.CallHook("OnPlayerBanned", playerName, steamId, player?.Address ?? "0", reason);
-                Interface.CallHook("OnUserBanned", playerName, playerId, player?.Address ?? "0", reason);
+                Interface.CallHook("OnPlayerBanned", playerName, steamId, player?.Address ?? "0", reason, expiry);
+                Interface.CallHook("OnUserBanned", playerName, playerId, player?.Address ?? "0", reason, expiry);
             }
         }
 


### PR DESCRIPTION
Checked the hook configuration `Interface.CallHook("IOnServerUsersSet", uid, group, username, notes, expiry);` which already provides the arguments just needs to be passed along. Let me know if anything else needs to change 👍 