### PR TITLE
OnSubmitInputItems hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15615,6 +15615,32 @@
             "BaseHookName": "OnEngineStart",
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 21,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnSubmitInputItems",
+            "HookName": "OnSubmitInputItems",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Mailbox",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "SubmitInputItems",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "OgNkvYvB3EnWO9YH2P0Sk76FGg9cTHvCjRajtzgfk1Y=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15619,7 +15619,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 21,
+            "InjectionIndex": 12,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, l0",


### PR DESCRIPTION
`object OnSubmitInputItems(BasePlayer player, Item item)`

Called whenever someone press submit in the dropbox or mailbox (https://gyazo.com/2ff42228e4a49ba3e3981bd46a340ff2).

Using this to listen for whenever someone submits an item via dropbox or mailbox. 