### PR TITLE
OnStructureUpgrade changes & added OnItemStacked

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -637,7 +637,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 37,
+            "InjectionIndex": 33,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player, l0",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -476,7 +476,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 92,
+            "InjectionIndex": 100,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0",
@@ -637,7 +637,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 33,
+            "InjectionIndex": 37,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player, l0",
@@ -34034,6 +34034,516 @@
             ]
           },
           "MSILHash": "4osFyUWXrAggoRzs7vhPacYm8tF3fwewKVHFvu8Joy4="
+        },
+        {
+          "Name": "AutoTurret::ScheduleForTargetScan",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "ScheduleForTargetScan",
+            "FullTypeName": "System.Void",
+            "Parameters": []
+          },
+          "MSILHash": "WkHNCzqTDLOh0Z/9AcObagZTuM93cHQFyGoK5ZLsWi4="
+        },
+        {
+          "Name": "AutoTurret::ApplyDamage",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "ApplyDamage",
+            "FullTypeName": "System.Void",
+            "Parameters": [
+              "BaseCombatEntity",
+              "UnityEngine.Vector3",
+              "UnityEngine.Vector3"
+            ]
+          },
+          "MSILHash": "nRNuYuacf3uc2zHxu7idUMILvn65zYuk3hC2uyVXTXk="
+        },
+        {
+          "Name": "AutoTurret::GetAngle",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "GetAngle",
+            "FullTypeName": "System.Single",
+            "Parameters": [
+              "UnityEngine.Vector3",
+              "UnityEngine.Vector3",
+              "System.Single",
+              "System.Single"
+            ]
+          },
+          "MSILHash": "JNfsdaUODjNt18+bBOA4OMoFPvKQ/a341/w3K6KjQYE="
+        },
+        {
+          "Name": "AutoTurret::HasGenericFireable",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "HasGenericFireable",
+            "FullTypeName": "System.Boolean",
+            "Parameters": []
+          },
+          "MSILHash": "lNl86bNfn3oUw03ED/HV2pdEwYrNpRN6jgvRnvohPkw="
+        },
+        {
+          "Name": "AutoTurret::initialAimDir",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "initialAimDir",
+            "FullTypeName": "UnityEngine.Vector3 AutoTurret::initialAimDir",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "AutoTurret::peekIndex",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "peekIndex",
+            "FullTypeName": "System.Int32 AutoTurret::peekIndex",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "AutoTurret::rcIdentifier",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AutoTurret",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "rcIdentifier",
+            "FullTypeName": "System.String AutoTurret::rcIdentifier",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::drinkMovementSpeed",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2,
+            4
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "drinkMovementSpeed",
+            "FullTypeName": "System.Single BasePlayer::drinkMovementSpeed",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::drinkRange",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2,
+            4
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "drinkRange",
+            "FullTypeName": "System.Single BasePlayer::drinkRange",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::TimeCategoryUpdateFrequency",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2,
+            4
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "TimeCategoryUpdateFrequency",
+            "FullTypeName": "System.Single BasePlayer::TimeCategoryUpdateFrequency",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::Find",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 1,
+          "TargetExposure": [
+            2,
+            4
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "Find",
+            "FullTypeName": "BasePlayer",
+            "Parameters": [
+              "System.String",
+              "System.Collections.Generic.IEnumerable`1<BasePlayer>"
+            ]
+          },
+          "MSILHash": "9W6AvKTB2jZPqySVccbZ/RmQ1dOJOUUWZW7Fp3fO74s="
+        },
+        {
+          "Name": "BasePlayer::blockHeldInputTimer",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "blockHeldInputTimer",
+            "FullTypeName": "TimeSince BasePlayer::blockHeldInputTimer",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::currentGesture",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "currentGesture",
+            "FullTypeName": "GestureConfig BasePlayer::currentGesture",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::fallTickRate",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "fallTickRate",
+            "FullTypeName": "System.Single BasePlayer::fallTickRate",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::fallVelocity",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "fallVelocity",
+            "FullTypeName": "System.Single BasePlayer::fallVelocity",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::gestureFinishedTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "gestureFinishedTime",
+            "FullTypeName": "TimeUntil BasePlayer::gestureFinishedTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::modelStateTick",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "modelStateTick",
+            "FullTypeName": "ModelState BasePlayer::modelStateTick",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::nextColliderRefreshTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextColliderRefreshTime",
+            "FullTypeName": "System.Single BasePlayer::nextColliderRefreshTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::nextSeatSwapTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextSeatSwapTime",
+            "FullTypeName": "System.Single BasePlayer::nextSeatSwapTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::nextTimeCategoryUpdate",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextTimeCategoryUpdate",
+            "FullTypeName": "System.Single BasePlayer::nextTimeCategoryUpdate",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::nextUnderwearValidationTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextUnderwearValidationTime",
+            "FullTypeName": "System.Single BasePlayer::nextUnderwearValidationTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::playerColliderDucked",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "playerColliderDucked",
+            "FullTypeName": "BasePlayer/CapsuleColliderInfo BasePlayer::playerColliderDucked",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::playerColliderLyingDown",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "playerColliderLyingDown",
+            "FullTypeName": "BasePlayer/CapsuleColliderInfo BasePlayer::playerColliderLyingDown",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::playerColliderStanding",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "playerColliderStanding",
+            "FullTypeName": "BasePlayer/CapsuleColliderInfo BasePlayer::playerColliderStanding",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::playerRigidbody",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "playerRigidbody",
+            "FullTypeName": "UnityEngine.Rigidbody BasePlayer::playerRigidbody",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::SpectateOffset",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "SpectateOffset",
+            "FullTypeName": "System.Int32 BasePlayer::SpectateOffset",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15615,6 +15615,35 @@
             "BaseHookName": "OnEngineStart",
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 109,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l3, this, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnItemStacked",
+            "HookName": "OnItemStacked",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Item",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "MoveToContainer",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "ItemContainer",
+                "System.Int32",
+                "System.Boolean",
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "VVmQczZZC9ad7nkA6FTpnZKlrlOY3SncFx1cLrdNRm0=",
+            "BaseHookName": "OnItemStacked,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Injecting this method after the BaseCombatEntity#SecondsSinceAttacked check doesn't make any sense, seen as OnStructureRepair does it before.

**Before Commit**
![image](https://user-images.githubusercontent.com/28874107/113603805-656aae00-9612-11eb-8567-8b5642a46f9b.png)

**After Commit**
![image](https://user-images.githubusercontent.com/28874107/113603835-6e5b7f80-9612-11eb-8d3a-87d495615f49.png)

**Current OnStructureRepair**
![image](https://user-images.githubusercontent.com/28874107/113612024-46254e00-961d-11eb-8ef5-612b7a05113d.png)