### PR TITLE
Change OnStructureUpgrade position

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -637,7 +637,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 37,
+            "InjectionIndex": 33,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player, l0",


### PR DESCRIPTION
Injecting this method after the BaseCombatEntity#SecondsSinceAttacked check doesn't make any sense, seen as OnStructureRepair does it before.

**Before Commit**
![image](https://user-images.githubusercontent.com/28874107/113603805-656aae00-9612-11eb-8567-8b5642a46f9b.png)

**After Commit**
![image](https://user-images.githubusercontent.com/28874107/113603835-6e5b7f80-9612-11eb-8d3a-87d495615f49.png)

**Current OnStructureRepair**
![image](https://user-images.githubusercontent.com/28874107/113612024-46254e00-961d-11eb-8ef5-612b7a05113d.png)