### PR TITLE
Add OnItemStacked hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15641,7 +15641,7 @@
               ]
             },
             "MSILHash": "VVmQczZZC9ad7nkA6FTpnZKlrlOY3SncFx1cLrdNRm0=",
-            "BaseHookName": "OnItemStacked,
+            "BaseHookName": "OnItemStacked",
             "HookCategory": "Item"
           }
         }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15641,7 +15641,7 @@
               ]
             },
             "MSILHash": "VVmQczZZC9ad7nkA6FTpnZKlrlOY3SncFx1cLrdNRm0=",
-            "BaseHookName": "OnItemStacked",
+            "BaseHookName": null,
             "HookCategory": "Item"
           }
         }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15615,6 +15615,35 @@
             "BaseHookName": "OnEngineStart",
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 109,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l3, this, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnItemStacked",
+            "HookName": "OnItemStacked",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Item",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "MoveToContainer",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "ItemContainer",
+                "System.Int32",
+                "System.Boolean",
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "VVmQczZZC9ad7nkA6FTpnZKlrlOY3SncFx1cLrdNRm0=",
+            "BaseHookName": "OnItemStacked,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
I've added the hook "OnItemStacked" hook because there's no way of determining if CanStack was successful.

Example:
```csharp
void OnItemStacked(Item newItem, Item oldItem, ItemContainer newContainer)
```

**Code**

![image](https://user-images.githubusercontent.com/28874107/114453936-0b389280-9ba8-11eb-9318-1343945d1480.png)
