### PR TITLE
Passing created entity in OnItemDeployed [Regular]

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -424,7 +424,7 @@
             "InjectionIndex": 117,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, l5",
+            "ArgumentString": "this, l5, l6",
             "HookTypeName": "Simple",
             "Name": "OnItemDeployed [Regular]",
             "HookName": "OnItemDeployed",


### PR DESCRIPTION
I'm not sure that this is how this hook always worked, but there is no way to get created entity right now, yet the modDeployable can be accessed from the deployer itself:
![image](https://user-images.githubusercontent.com/31519848/114845168-37d8ee00-9de4-11eb-89f5-e8a6992c456f.png)
