### PR TITLE
Added OnIsOwned hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Rust",
-  "TargetDirectory": "C:\\Users\\zloyk\\Desktop\\rustserv\\rustserv\\RustDedicated_Data\\Managed",
+  "TargetDirectory": "E:\\Servers\\Rust\\RustDedicated_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",
@@ -15625,7 +15625,7 @@
             "ArgumentString": "this",
             "HookTypeName": "Simple",
             "Name": "IsOwnedBy",
-            "HookName": "OnIsOwnedBy",
+            "HookName": "CanUseGesture",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "GestureConfig",
             "Flagged": false,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Rust",
-  "TargetDirectory": "E:\\Servers\\Rust\\RustDedicated_Data\\Managed",
+  "TargetDirectory": "C:\\Users\\zloyk\\Desktop\\rustserv\\rustserv\\RustDedicated_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",
@@ -15614,6 +15614,32 @@
             "MSILHash": "kxTPZzOQvb51sC/onVuxsZ0s6MgZzKlIyIdp9Ap/5GY=",
             "BaseHookName": "OnEngineStart",
             "HookCategory": "Vehicle"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 1,
+            "ArgumentString": "this",
+            "HookTypeName": "Simple",
+            "Name": "IsOwnedBy",
+            "HookName": "OnIsOwnedBy",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "GestureConfig",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "IsOwnedBy",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "C+J+NWt1DPhGCXDzxNhlYgAaeiCIbIQV0j2P/49HCZ8=",
+            "BaseHookName": null,
+            "HookCategory": null
           }
         }
       ],


### PR DESCRIPTION
Added OnIsOwned hook to unlock _dance_01 (834887525)_ gesture.

Code Before:
```
public bool IsOwnedBy(BasePlayer player)
{
	return this.forceUnlock || (this.dlcItem != null && this.dlcItem.CanUse(player)) || (this.inventoryItem != null && player.blueprints.steamInventory.HasItem(this.inventoryItem.id));
}
```
Code After:
```
public bool IsOwnedBy(BasePlayer player)
{
	object returnvar = Interface.CallHook("CanUseGesture", this);
	if (returnvar != null)
	{
		return returnvar is bool && (bool)returnvar;
	}
	return this.forceUnlock || (this.dlcItem != null && this.dlcItem.CanUse(player)) || (this.inventoryItem != null && player.blueprints.steamInventory.HasItem(this.inventoryItem.id));
}
```