### PR TITLE
Call OnBookmarkControlEnded when switching bookmarks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15615,6 +15615,63 @@
             "BaseHookName": "OnEngineStart",
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 74,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0, l6",
+            "HookTypeName": "Simple",
+            "Name": "OnBookmarkControlEnded [2]",
+            "HookName": "OnBookmarkControlEnded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ComputerStation",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "BeginControllingBookmark",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "1MQGejmAMZSMzpbYkP5vruAc6Jtpl+g8F5zNL8ra2Qs=",
+            "BaseHookName": "OnBookmarkControlStarted",
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 66,
+            "RemoveCount": 1,
+            "Instructions": [
+              {
+                "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 80
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnBookmarkControlEnded [2] [patch]",
+            "HookName": "OnBookmarkControlEnded [2] [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ComputerStation",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "BeginControllingBookmark",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "1MQGejmAMZSMzpbYkP5vruAc6Jtpl+g8F5zNL8ra2Qs=",
+            "BaseHookName": "OnBookmarkControlEnded [2]",
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Decompiled code of method being hooked.
```csharp
if (component.CanControl() && !(component.GetIdentifier() != text) && Interface.CallHook("OnBookmarkControl", this, player, text, component) == null)
{
    BaseEntity baseEntity = currentlyControllingEnt.Get(serverside: true);
    if ((bool)baseEntity)
    {
        IRemoteControllable component2 = baseEntity.GetComponent<IRemoteControllable>();
        component2?.StopControl();
        Interface.CallHook("OnBookmarkControlEnded", this, player, component2);
    }
    player.net.SwitchSecondaryGroup(baseNetworkable.net.group);
    currentlyControllingEnt.uid = baseNetworkable.net.ID;
    SendNetworkUpdateImmediate();
    SendControlBookmarks(player);
    component.InitializeControl(player);
    InvokeRepeating(ControlCheck, 0f, 0f);
    Interface.CallHook("OnBookmarkControlStarted", this, player, text, component);
}
```