### PR TITLE
Added OnCraneTakeDamageWhenNotInJunkyard hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16023,6 +16023,30 @@
             "BaseHookName": null,
             "HookCategory": "Player"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 101,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 1,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "VehicleFixedUpdate",
+            "HookName": "OnCraneTakeDamageWhenNotInJunkyard",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseCrane",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 1,
+              "Name": "VehicleFixedUpdate",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "6i2WLMuwNHB3xqTHNiUYdZlU/k8Icc31gdSu/h7gywM=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
### Added OnCraneTakeDamageWhenNotInJunkyard hook

Example:
```c#
bool? OnCraneTakeDamageWhenNotInJunkyard(BaseCrane crane)
{
    crane.GetDriver()?.IPlayer.Reply("OnCraneTakeDamageWhenNotInJunkyard works!");
    crane.lastDamagePos = crane.transform.position;
    return null;
}
```

**_But_**
` crane.lastDamagePos = crane.transform.position; ` is _**needed**_, otherwise it would crash