### PR TITLE
Add IsSleepingBagValid hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16176,6 +16176,33 @@
             "BaseHookName": null,
             "HookCategory": "Player"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "IsSleepingBagValid",
+            "HookName": "IsSleepingBagValid",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "SleepingBag",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ValidForPlayer",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "System.UInt64",
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "NPeOF52CCYRDvClXOnxey1p26kcJAJrsh1y1A0zE4q0=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16201,7 +16201,7 @@
             },
             "MSILHash": "NPeOF52CCYRDvClXOnxey1p26kcJAJrsh1y1A0zE4q0=",
             "BaseHookName": null,
-            "HookCategory": null
+            "HookCategory": "Entity"
           }
         }
       ],


### PR DESCRIPTION
`IsSleepingBadValid(SleepingBag bag, ulong targetPlayerID, bool ignoreTimers)`
This hook is an addition to the `OnRespawnInformationGiven` hook as if you want to add a new option, the sleeping bag will need to be valid for the player to spawn on it.

**Code Before**
```csharp
public virtual bool ValidForPlayer(ulong playerID, bool ignoreTimers)
{
	return this.deployerUserID == playerID && (ignoreTimers || this.unlockTime < Time.realtimeSinceStartup);
}
```

**Code After**
```csharp
public virtual bool ValidForPlayer(ulong playerID, bool ignoreTimers)
{
	object returnvar = Interface.CallHook("IsSleepingBagValid", this, playerID, ignoreTimers);
	if (returnvar is bool)
	{
		return (bool)returnvar;
	}
	return this.deployerUserID == playerID && (ignoreTimers || this.unlockTime < Time.realtimeSinceStartup);
}
```