### PR TITLE
Auto Turrets should keep scanning targets when one is blocked

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16385,6 +16385,45 @@
             "BaseHookName": null,
             "HookCategory": "NPC"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 86,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|AutoTurret|target"
+              },
+              {
+                "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 87
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "TargetScan[patch]",
+            "HookName": "TargetScan[patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "AutoTurret",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "TargetScan",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "YdqlkxSk5JJUMnkw/fbriUaHnkPUP3Vep5Yuf7Qwyi0=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
This change patches the `AutoTurret.TargetScan` method to keep checking for targets in its trigger when one is blocked by returning non-null in the `OnTurretTarget` hook.

### Original problem
When a plugin returns non-null in the `OnTurretTarget` hook to prevent a player from being targeted, all other entities in the turret's trigger are skipped for that scan iteration (approximately 1 scan per second). For as long as the ignored target remains in the trigger and visible to the turret, all other targets will be continuously skipped. Plugins typically address this by authorizing the ignored target so that they will be skipped earlier in the logic on subsequent target scans, but that doesn't fix the following problems.
- Other targets are not acquired until the next target scan
- Plugins that manage team/friend/clan sharing have to detect relationship changes and update the auth list of various turrets rather than rely on lazy target evaluation
- Authorizing players is not suitable for targets that need to be temporarily ignored due their state (e.g., vanished, in an event, wearing stealth armor)
- Non-player targets (e.g., a plugin could allow targeting drones) can't be authorized to a turret, so plugins have to use the far more expensive `CanBeTargeted` hook for those cases, because blocking the target with `OnTurretTarget` would cause other targets to be skipped indefinitely

### Benefits of this change
- No more delay between blocking a target and the next target being acquired
- Allows plugins to block specific player or even non-player entities from being targeted, while maintaining high performance
- Fixes bugs in existing plugins that do not authorize the target when blocking them