### PR TITLE
Add hook to prevent CCTV direction change

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16385,6 +16385,32 @@
             "BaseHookName": null,
             "HookCategory": "NPC"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 14,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnCCTVDirectionChange",
+            "HookName": "OnCCTVDirectionChange",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "CCTV_RC",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Server_SetDir",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "4gaLp1xVDk1CWolE88UOpOfLBLeigwGnkvFwtO1QS64=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
bool? OnCCTVDirectionChange(CCTV_RC camera, BasePlayer player)
```
- Called when a player attempts to set the direction of a CCTV camera
- Returning non-null cancels the default behavior