### PR TITLE
New hook OnVendingMachineRefill

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7391,7 +7391,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, this",
             "HookTypeName": "Simple",
-            "Name": "CanAdministerVending [npc]",
+            "Name": "CanAdministerVending [NPC]",
             "HookName": "CanAdministerVending",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCVendingMachine",
@@ -16920,6 +16920,30 @@
             "MSILHash": "0C1+c0xi0SgtdDqbYMP3WIs4j01WlvZB/YEWL8hhpaE=",
             "BaseHookName": null,
             "HookCategory": "Resource"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 25,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnVendingMachineRefill [NPC]",
+            "HookName": "OnVendingMachineRefill",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCVendingMachine",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Refill",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "62FasNCKI0yu4MQwoJ8gaf7qrQr2l2SWXGcJxvZxIow=",
+            "BaseHookName": null,
+            "HookCategory": "Vending"
           }
         }
       ],
@@ -38477,6 +38501,25 @@
             ]
           },
           "MSILHash": "Z9QaByiEr0ortXV7eqbMM4dc+af/zMlKA5tH4SC0NqY="
+        },
+        {
+          "Name": "NPCVendingMachine::refillTimes",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "NPCVendingMachine",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "refillTimes",
+            "FullTypeName": "System.Single[] NPCVendingMachine::refillTimes",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
Solves an edge case leading to "Index Out of Bounds" on `NPCVendingMachine.Refill()` when the number of items inside a `NPCVendingMachine` are modified after the execution of `NPCVendingMachine.ServerInit()`.

`NPCVendingMachine.ServerInit()` starts a background task invoking `NPCVendingMachine.Refill()` every second. The first time it executes, `float[] refillTimes` gets initialized with the size of `this.vendingOrders.orders.Length` and it will never be re-evaluated for changes on the number of orders inside the vending machine during runtime.

This PR provides two changes:
1) Changes the visibility of `float[] refillTimes` to `public`
2) Adds a new `OnVendingMachineRefill(NPCVendingMachine machine)` hook

Usage example:
```cs
private object OnVendingMachineRefill(NPCVendingMachine machine)
{
	if (machine.vendingOrders.orders.Length != machine.refillTimes.Length)
		machine.refillTimes = new float[machine.vendingOrders.orders.Length];
	return null;
}
```

Or a more realistic alternative..
```cs
machine.vendingOrders.orders = myOrders.ToArray();
machine.refillTimes = new float[machine.vendingOrders.orders.Length];
machine.InstallFromVendingOrders();
```

I was unsure to name this hook `OnNPCVendingMachineRefill` but as another NPCVendingMachine hooks were already using the `[NPC]` suffix I went with it.

There is also a small ~~OCD~~ cosmetic change inside this PR which changes the display name of `CanAdministerVending [npc]` to uppercase `NPC`.