### PR TITLE
Add OnEntityPickedUp hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16947,6 +16947,33 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnEntityPickedUp",
+            "HookName": "OnEntityPickedUp",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseCombatEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnPickedUp",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Item",
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "+u2GCtSHTDWu7iqcjcFKh98FNKhbrQfPRx+LI73xrGk=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
void OnEntityPickedUp(BaseCombatEntity entity, Item createdItem, BasePlayer player)
```
- Called after an entity has been picked up, before anything is done with the entity's inventory
- One use case is to clear the contents of the entity's inventory, to prevent those contents from going into the item's inventory or into the player inventory (e.g., to prevent a shotgun trap's ammo from being given to the player)