### PR TITLE
Add OnPickupEntity

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16947,6 +16947,32 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 46,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, a0.player, this",
+            "HookTypeName": "Simple",
+            "Name": "OnPickupEntity",
+            "HookName": "OnPickupEntity",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseCombatEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "RPC_PickupStart",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "hiv7NUxh5dHb1xYbgzloTmry0kErauLRa133EJ3q2L0=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Currently there is a hook for disabling the ability to pickup a deployable (`CanPickupEntity`),
but there is no hook for after it has been picked up, and after the item has been created.
This PR adds that hook, giving the player, item, and entity as arguments, and with no return behaviour.
It runs after the item has been given, but before the deployed entity is destroyed.