### PR TITLE
Fix procedural map generation

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -39080,44 +39080,6 @@
             "Parameters": []
           },
           "MSILHash": ""
-        },
-        {
-          "Name": "DungeonBaseLink::sockets",
-          "AssemblyName": "Assembly-CSharp.dll",
-          "TypeName": "DungeonBaseLink",
-          "Type": 0,
-          "TargetExposure": [
-            2
-          ],
-          "Flagged": false,
-          "Signature": {
-            "Exposure": [
-              0
-            ],
-            "Name": "sockets",
-            "FullTypeName": "System.Collections.Generic.List`1<DungeonBaseSocket> DungeonBaseLink::sockets",
-            "Parameters": []
-          },
-          "MSILHash": ""
-        },
-        {
-          "Name": "DungeonBaseLink::volumes",
-          "AssemblyName": "Assembly-CSharp.dll",
-          "TypeName": "DungeonBaseLink",
-          "Type": 0,
-          "TargetExposure": [
-            2
-          ],
-          "Flagged": false,
-          "Signature": {
-            "Exposure": [
-              0
-            ],
-            "Name": "volumes",
-            "FullTypeName": "System.Collections.Generic.List`1<DungeonVolume> DungeonBaseLink::volumes",
-            "Parameters": []
-          },
-          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
This fixes a `DivideByZeroException: Attempted to divide by zero` error that was occurring while generating maps on staging. This appears to be happening because the visibility of the `DungeonBaseLink::sockets` and `DungeonBaseLink::volumes` fields were changed to public via Oxide. Changing list fields to public visibility causes Unity to initialize them with an empty list. That is a problem because the Rust code expects these two fields to be null initially. If they are not null initially, Rust will not assign the correct values to them, leaving them perpetually empty, which eventually causes the division by 0 when the procedural generation process uses the list size as a divisor.