### PR TITLE
ServerMgr: Expose field and add restart-related hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -17049,6 +17049,60 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 8,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 0,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnServerRestartInterrupt",
+            "HookName": "OnServerRestartInterrupt",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerMgr",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RestartServer",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "xQqd1l4OdCgri/SH1AMaVoJ9sdDpgZOV/BXRbc/g9Gs=",
+            "BaseHookName": null,
+            "HookCategory": "Server"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 38,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0,a1",
+            "HookTypeName": "Simple",
+            "Name": "OnServerRestart",
+            "HookName": "OnServerRestart",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerMgr",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RestartServer",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "xQqd1l4OdCgri/SH1AMaVoJ9sdDpgZOV/BXRbc/g9Gs=",
+            "BaseHookName": "OnServerRestartInterrupt",
+            "HookCategory": "Server"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -39101,6 +39101,25 @@
             ]
           },
           "MSILHash": "zuUZtzGrQG51LD/b+AAEibaDYPUXaQXAH7+SOmSJttk="
+        },
+        {
+          "Name": "ServerMgr::restartCoroutine",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "ServerMgr",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "restartCoroutine",
+            "FullTypeName": "System.Collections.IEnumerator ServerMgr::restartCoroutine",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
## Exposed field:
`ServerMgr.restartCoroutine` - stores coroutine used for server restarts
## New hooks:
### ServerMgr::RestartServer

- `OnServerRestart(string notice, int delaySeconds): Exit if non-null` Gets called right before restart coroutine is initialized, allows to cancel default behaviour.
- `OnServerRestartInterrupt(): Exit if non-null` Gets called after the check if restart coroutine != null and before server "Restart interrupted!" message, allows to cancel both interruption and following re-initialization of restart process.