### PR TITLE
Automatically determine Extension.Branch

### DIFF
--- a/src/Oxide.Rust.csproj
+++ b/src/Oxide.Rust.csproj
@@ -20,6 +20,7 @@
     <GameExe>RustDedicated.exe;RustDedicated</GameExe>
     <ManagedDir>RustDedicated_Data/Managed</ManagedDir>
     <NoWarn>NU1701</NoWarn>
+    <GitBranch></GitBranch>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Oxide.References" Version="2.0.*" />
@@ -56,6 +57,17 @@
   <ItemGroup>
     <PatchedFiles Include="$(TargetDir)\Assembly-CSharp.dll; $(TargetDir)\Facepunch.Console.dll; $(TargetDir)\Facepunch.Network.dll; $(TargetDir)\Facepunch.Rcon.dll; $(TargetDir)\Facepunch.UnityEngine.dll; $(TargetDir)\NewAssembly.dll" />
   </ItemGroup>
+  <Target Name="AddGitBranchMeta" BeforeTargets="CoreGenerateAssemblyInfo">
+    <Exec Command="git rev-parse --abbrev-ref HEAD" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="True">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitBranch"/>
+    </Exec>
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="$(GitBranch) != ''">
+        <_Parameter1>GitBranch</_Parameter1>
+        <_Parameter2>$(GitBranch)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\Game.targets" />
 </Project>

--- a/src/RustExtension.cs
+++ b/src/RustExtension.cs
@@ -2,6 +2,7 @@ using Oxide.Core;
 using Oxide.Core.Extensions;
 using Oxide.Plugins;
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Oxide.Game.Rust
@@ -15,6 +16,10 @@ namespace Oxide.Game.Rust
         internal static AssemblyName AssemblyName = Assembly.GetName();
         internal static VersionNumber AssemblyVersion = new VersionNumber(AssemblyName.Version.Major, AssemblyName.Version.Minor, AssemblyName.Version.Build);
         internal static string AssemblyAuthors = ((AssemblyCompanyAttribute)Attribute.GetCustomAttribute(Assembly, typeof(AssemblyCompanyAttribute), false)).Company;
+        internal static string AssemblyBranch =
+            Attribute.GetCustomAttributes(Assembly, typeof(AssemblyMetadataAttribute))
+                .Cast<AssemblyMetadataAttribute>()
+                .Single(attr => attr.Key == "GitBranch").Value;
 
         /// <summary>
         /// Gets whether this extension is for a specific game
@@ -39,7 +44,7 @@ namespace Oxide.Game.Rust
         /// <summary>
         /// Gets the branch of this extension
         /// </summary>
-        public override string Branch => "public"; // TODO: Handle this programmatically
+        public override string Branch => AssemblyBranch;
 
         /// <summary>
         /// Default game-specific references for use in plugins


### PR DESCRIPTION
## Oxide.Rust.csproj
Add target which injects AssemblyMetadataAttribute into built assembly which contains key of GitBranch and value of git branch build originated from
## RustExtension
Retrieve attribute data mentioned above and place it in Extension.Branch