### PR TITLE
Add OnOpenVendingShop hook to NPCTalking

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3063,7 +3063,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
             "HookTypeName": "Simple",
-            "Name": "OnOpenVendingShop",
+            "Name": "OnOpenVendingShop [VendingMachine]",
             "HookName": "OnOpenVendingShop",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "VendingMachine",
@@ -17436,6 +17436,33 @@
             "MSILHash": "lBigoe6HPdWgmUywXNLHnTU0YUAEpRcaWB3RJPKVstU=",
             "BaseHookName": null,
             "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 29,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l1, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnOpenVendingShop [NPCTalking]",
+            "HookName": "OnOpenVendingShop",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCTalking",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnConversationAction",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer",
+                "System.String"
+              ]
+            },
+            "MSILHash": "1ITepcufk4Srnj36bU9AToXp1pzpa5qpflNodhl3s0o=",
+            "BaseHookName": null,
+            "HookCategory": "Vending"
           }
         }
       ],


### PR DESCRIPTION
This adds the existing `OnOpenVendingShop` hook to the `NPCTalking` class so that it is also called when a player opens an invisible vending machine from an NPC conversation.

```cs
void OnOpenVendingShop(VendingMachine machine, BasePlayer player)
```

The ideal naming would be `OnVendingShopOpen`, to be consistent with the new standards, but this is an existing hook already used in another class, so it would not make sense to change the name for this usage.