### PR TITLE
Exposed ItemBasedFlowRestrictor.inventory as public

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -39850,6 +39850,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "ItemBasedFlowRestrictor::inventory",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "ItemBasedFlowRestrictor",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "inventory",
+            "FullTypeName": "ItemContainer ItemBasedFlowRestrictor::inventory",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
Tested with map-spawned and custom-spawned Fuse Boxes, who knew that the FuseBox class is a dummy and the actual class for the entity is ItemBasedFlowRestrictor. Nothing broke.

All the other fields in that class are already public and I couldn't think of anything else to hook up/expose