### PR TITLE
Fuse Box stuff, exposed its inventory field and added missing OnLootEntityEnd hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -17640,6 +17640,32 @@
             "BaseHookName": null,
             "HookCategory": "Vending"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this",
+            "HookTypeName": "Simple",
+            "Name": "OnLootEntityEnd [FuseBox]",
+            "HookName": "OnLootEntityEnd",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ItemBasedFlowRestrictor",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PlayerStoppedLooting",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "+u2GCtSHTDWu7iqcjcFKh98FNKhbrQfPRx+LI73xrGk=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Who knew that FuseBox is an empty dummy class and all the juice has been inside ItemBasedFlowRestrictor all along.

Exposed inventory field to aid with modding. Following the advice of White Thunder I tested if it would break any vanilla Fuse Boxes and it wouldn't.

Also turns out that if a player stops looting a Fuse Box, it doesn't call the OnLootEntityEnd hook. It would have been called during OnLootEntityStart, so this makes things symmetrical in that regard.

This is a second and definite pull request.