### PR TITLE
Add OnNetworkSubscriptionsUpdate hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -40874,6 +40874,117 @@
             "BaseHookName": null,
             "HookCategory": "Player"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 43,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnNetworkSubscriptionsUpdate"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldloc_1",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldloc_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "brtrue_s",
+                "OpType": "Instruction",
+                "Operand": 122
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnNetworkSubscriptionsUpdate",
+            "HookName": "OnNetworkSubscriptionsUpdate",
+            "AssemblyName": "Facepunch.Network.dll",
+            "TypeName": "Network.Networkable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "UpdateSubscriptions",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "System.Int32",
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "cptic6PumTgzDzaGTSzlJaU0kThAKbSfNb0golYjFsI=",
+            "BaseHookName": null,
+            "HookCategory": "Networking"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 33,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnNetworkSubscriptionsUpdate"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldloc_1",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ldnull",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "brtrue_s",
+                "OpType": "Instruction",
+                "Operand": 60
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnNetworkSubscriptionsUpdate [2]",
+            "HookName": "OnNetworkSubscriptionsUpdate",
+            "AssemblyName": "Facepunch.Network.dll",
+            "TypeName": "Network.Networkable",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "UpdateHighPrioritySubscriptions",
+              "ReturnType": "System.Boolean",
+              "Parameters": []
+            },
+            "MSILHash": "gN7B2d+U+pcqgTS9l5Bf3WcnsPlFtxUP/SemvfpmFhc=",
+            "BaseHookName": null,
+            "HookCategory": "Networking"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
object OnNetworkSubscriptionsUpdate(Network.Networkable networkable, List<Network.Visibility.Group> groupsToAdd, List<Network.Visibility.Group> groupsToRemove)
```
This hook is called after determining which network groups a player should be subscribed to and unsubscribed from (based on position). The `Network.Networkable`  parameter represents the `BasePlayer.net` object. The `BasePlayer` can be obtained from `networkable.handler as BasePlayer`.

Use cases:
- Return non-null to replace the logic for subscribing/unsubscribing the player from various network groups
- Add/remove network groups from the passed lists to supplement the vanilla network groups (e.g., subscribe the player to a persistent network group independent of position that only select players are subscribed to)

Testing done:
- Verified that the player correctly subscribed and unsubscribed to network groups based on position, while the hook was not used
- Verified that returning `false` prevented the vanilla logic (network subscriptions did not change when moving a significant distance)
- Verified that removing a custom-subscribed network group from the `groupsToRemove` list prevented the player from becoming unsubscribed