### PR TITLE
Expose various methods/fields as public

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -40524,6 +40524,63 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "StabilityEntity::supports",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "StabilityEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "supports",
+            "FullTypeName": "System.Collections.Generic.List`1<StabilityEntity/Support> StabilityEntity::supports",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "StabilityEntity/Support",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "StabilityEntity/Support",
+          "Type": 3,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "Support",
+            "FullTypeName": "StabilityEntity/Support",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BaseEntity::links",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "links",
+            "FullTypeName": "System.Collections.Generic.List`1<EntityLink> BaseEntity::links",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
- Expose various fields and a class to be public for building stability

- Made StabilityEntity.Support class public, This class is a nested class

- Exposed BaseEntityl.links field to be public
`System.Collections.Generic.List<EntityLink> links = new System.Collections.Generic.List<EntityLink>();`

- Exposed StabilityEntity.supports field to be public
 `List<StabilityEntity.Support> supports;`


All these fields/classes are only used for building and are used when working out stability for building blocks.