### PR TITLE
Move OnCorpsePopulate

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -17399,7 +17399,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 12,
+            "InjectionIndex": 92,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l1",


### PR DESCRIPTION
Moved OnCorpsePopulate for FrankensteinPet to after the corpse has spawned and inventory has been stripped. This matches other cases of OnCorpsePopulate