### PR TITLE
Expose EntityFuelSystem.GetFuelContainer() as public

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -41353,6 +41353,25 @@
             ]
           },
           "MSILHash": "PgzW/9B6wsf3/sPOLYR+6k+3CZenTev/ktffr4GGlM4="
+        },
+        {
+          "Name": "EntityFuelSystem::GetFuelContainer",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "EntityFuelSystem",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              2
+            ],
+            "Name": "GetFuelContainer",
+            "FullTypeName": "StorageContainer",
+            "Parameters": []
+          },
+          "MSILHash": "oYVzP20Awo9GkQAwv5eOHhEgU01ujDA5gqmvtV92U20="
         }
       ],
       "Fields": [


### PR DESCRIPTION
This method is already `public` in today's Rust, but it's `private` in tomorrow's Rust, so this modifier should ensure it stays public. This should be merged prior to the next Oxide update to avoid breaking many plugins.