### PR TITLE
More accurate error handling for chat commands

### DIFF
--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using UnityEngine;
@@ -359,13 +360,13 @@ namespace Oxide.Game.Rust
             }
             catch (Exception ex)
             {
-                var innerException = ex;
-                var errorMessage = string.Empty;
-                var pluginName = string.Empty;
-                var stackTraceSb = new StringBuilder();
+                Exception innerException = ex;
+                string errorMessage = string.Empty;
+                string pluginName = string.Empty;
+                StringBuilder stackTraceSb = new StringBuilder();
                 while (innerException != null)
                 {
-                    var name = innerException.GetType().Name;
+                    string name = innerException.GetType().Name;
                     errorMessage = $"{name}: {innerException.Message}".TrimEnd(' ', ':');
                     stackTraceSb.AppendLine(innerException.StackTrace);
                     if (innerException.InnerException != null)
@@ -375,11 +376,11 @@ namespace Oxide.Game.Rust
                     innerException = innerException.InnerException;
                 }
 
-                var stackTrace = new StackTrace(ex, 0, true);
-                for (var i = 0; i < stackTrace.FrameCount; i++)
+                StackTrace stackTrace = new StackTrace(ex, 0, true);
+                for (int i = 0; i < stackTrace.FrameCount; i++)
                 {
-                    var frame = stackTrace.GetFrame(i);
-                    var method = frame.GetMethod();
+                    StackFrame frame = stackTrace.GetFrame(i);
+                    MethodBase method = frame.GetMethod();
                     if (method is null || method.DeclaringType is null) continue;
                     if (method.DeclaringType.Namespace == "Oxide.Plugins")
                     {

--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -9,9 +9,12 @@ using Oxide.Game.Rust.Libraries.Covalence;
 using Rust.Ai;
 using Rust.Ai.HTN;
 using Steamworks;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -343,13 +346,48 @@ namespace Oxide.Game.Rust
                 return;
             }
 
-            // Is it a valid chat command?
-            if (!Covalence.CommandSystem.HandleChatMessage(basePlayer.IPlayer, str) && !cmdlib.HandleChatCommand(basePlayer, cmd, args))
+            try
             {
-                if (Interface.Oxide.Config.Options.Modded)
+                // Is it a valid chat command?
+                if (!Covalence.CommandSystem.HandleChatMessage(basePlayer.IPlayer, str) && !cmdlib.HandleChatCommand(basePlayer, cmd, args))
                 {
-                    basePlayer.IPlayer.Reply(string.Format(lang.GetMessage("UnknownCommand", this, basePlayer.IPlayer.Id), cmd));
+                    if (Interface.Oxide.Config.Options.Modded)
+                    {
+                        basePlayer.IPlayer.Reply(string.Format(lang.GetMessage("UnknownCommand", this, basePlayer.IPlayer.Id), cmd));
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                var innerException = ex;
+                var errorMessage = string.Empty;
+                var pluginName = string.Empty;
+                var stackTraceSb = new StringBuilder();
+                while (innerException != null)
+                {
+                    var name = innerException.GetType().Name;
+                    errorMessage = $"{name}: {innerException.Message}".TrimEnd(' ', ':');
+                    stackTraceSb.AppendLine(innerException.StackTrace);
+                    if (innerException.InnerException != null)
+                    {
+                        stackTraceSb.AppendLine($"Rethrow as {name}");
+                    }
+                    innerException = innerException.InnerException;
+                }
+
+                var stackTrace = new StackTrace(ex, 0, true);
+                for (var i = 0; i < stackTrace.FrameCount; i++)
+                {
+                    var frame = stackTrace.GetFrame(i);
+                    var method = frame.GetMethod();
+                    if (method is null || method.DeclaringType is null) continue;
+                    if (method.DeclaringType.Namespace == "Oxide.Plugins")
+                    {
+                        pluginName = method.DeclaringType.Name;
+                    }
+                }
+
+                Interface.Oxide.LogError($"Failed to run command '/{cmd}' on plugin '{pluginName}'. ({errorMessage.Replace(Environment.NewLine, " ")}){Environment.NewLine}{stackTrace}");
             }
         }
 


### PR DESCRIPTION
Customized StackTrace/Frame handling for exceptions caused by chat commands in plugins.

Before:
```
20:45 [Error] Failed to call hook 'IOnPlayerCommand' on plugin 'RustCore v2.0.0' (ArgumentNullException: Value cannot be null.
Parameter name: source)
  at Oxide.Core.Plugins.CSPlugin.OnCallHook (System.String name, System.Object[] args) [0x000fb] in <9882f28dc2204b4dba514a9ad18f5042>:0 
  at Oxide.Core.Plugins.Plugin.CallHook (System.String hook, System.Object[] args) [0x00060] in <9882f28dc2204b4dba514a9ad18f5042>:0 
```

After:
```
21:40 [Error] Failed to run command '/test' on plugin 'Test'. (ArgumentNullException: Value cannot be null. Parameter name: source)
  at System.Linq.Enumerable.Where[TSource] (System.Collections.Generic.IEnumerable1[T] source, System.Func2[T,TResult] predicate) [0x0000d] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at Oxide.Plugins.Test.TestCommand (BasePlayer player, System.String command, System.String[] args) [0x00002] in <fab6aab8276048bc82b5789130b45204>:0 
  at Oxide.Game.Rust.Libraries.Command+ChatCommand.HandleCommand (BasePlayer sender, System.String name, System.String[] args) [0x0001b] in <ea4f5793175e4626b37bda42dbeead8f>:0 
  at Oxide.Game.Rust.Libraries.Command.HandleChatCommand (BasePlayer sender, System.String name, System.String[] args) [0x00015] in <ea4f5793175e4626b37bda42dbeead8f>:0 
  at Oxide.Game.Rust.RustCore.IOnPlayerCommand (BasePlayer basePlayer, System.String message) [0x000db] in <ea4f5793175e4626b37bda42dbeead8f>:0
```
