### PR TITLE
Add hook to avoid EnablePlayerCollider on vanished players

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -41353,6 +41353,160 @@
             ]
           },
           "MSILHash": "PgzW/9B6wsf3/sPOLYR+6k+3CZenTev/ktffr4GGlM4="
+        },
+        {
+          "Name": "BaseNavigator::stuckCheckPosition",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseNavigator",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "stuckCheckPosition",
+            "FullTypeName": "UnityEngine.Vector3 BaseNavigator::stuckCheckPosition",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "AttackEntity::StartAttackCooldownRaw",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AttackEntity",
+          "Type": 1,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              1
+            ],
+            "Name": "StartAttackCooldownRaw",
+            "FullTypeName": "System.Void",
+            "Parameters": [
+              "System.Single"
+            ]
+          },
+          "MSILHash": "i560nIYMblSZO+3tqVmOjtGvFWwJZ10j0cQZ/i1jCEM="
+        },
+        {
+          "Name": "AttackEntity::nextAttackTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "AttackEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextAttackTime",
+            "FullTypeName": "System.Single AttackEntity::nextAttackTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "HeldEntity::ownerItemUID",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "HeldEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              3
+            ],
+            "Name": "ownerItemUID",
+            "FullTypeName": "System.UInt32 HeldEntity::ownerItemUID",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "HeldEntity::holsterVisible",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "HeldEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "holsterVisible",
+            "FullTypeName": "System.Boolean HeldEntity::holsterVisible",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "HeldEntity::genericVisible",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "HeldEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "genericVisible",
+            "FullTypeName": "System.Boolean HeldEntity::genericVisible",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "SimpleShark::nextAttackTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SimpleShark",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextAttackTime",
+            "FullTypeName": "System.Single SimpleShark::nextAttackTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BaseNpc::nextAttackTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseNpc",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextAttackTime",
+            "FullTypeName": "System.Single BaseNpc::nextAttackTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
```
public virtual void EndSleeping()
    {
        if (!this.IsSleeping())
        {
            return;
        }
        this.SetPlayerFlag(BasePlayer.PlayerFlags.Sleeping, false);
        this.sleepStartTime = -1f;
        BasePlayer.sleepingPlayerList.Remove(this);
        if (this.userID < (long)10000000 && !BasePlayer.bots.Contains(this))
        {
            BasePlayer.bots.Add(this);
        }
        base.CancelInvoke(new Action(this.ScheduledDeath));
        base.InvokeRepeating(new Action(this.InventoryUpdate), 1f, 0.1f * Random.Range(0.99f, 1.01f));
        if (RelationshipManager.TeamsEnabled())
        {
            base.InvokeRandomized(new Action(this.TeamUpdate), 1f, 4f, 1f);
        }
        this.EnablePlayerCollider();
        this.AddPlayerRigidbody();
        this.SetServerFall(false);
        if (base.HasParent())
        {
            base.SetParent(null, true, false);
            base.ForceUpdateTriggers(true, true, true);
        }
        this.inventory.containerMain.OnChanged();
        this.inventory.containerBelt.OnChanged();
        this.inventory.containerWear.OnChanged();
        Interface.CallHook("OnPlayerSleepEnded", this);
        if (EACServer.playerTracker != null && this.net.connection != null)
        {
            using (TimeWarning timeWarning = TimeWarning.New("playerTracker.LogPlayerSpawn", 0))
            {
                Client client = EACServer.GetClient(this.net.connection);
                EACServer.playerTracker.LogPlayerSpawn(client, 0, 0);
            }
        }
    }
```
    
Ending sleep causes the player collider to be enabled. Vanished players will then set of traps and such. To solve this etiher of the following hooks would work
    A: object OnSleepEndingHook(BasePlayer player)
    B: object OnColliderEnabled(BasePlayer player, CapsuleCollider playerCollider)