### PR TITLE
Fixed NRE in OnItemCraft

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -9826,6 +9826,16 @@
                 "Operand": 80
               },
               {
+                "OpCode": "ldarg_s",
+                "OpType": "Parameter",
+                "Operand": 5
+              },
+              {
+                "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 77
+              },
+              {
                 "OpCode": "ldloc_0",
                 "OpType": "None",
                 "Operand": null


### PR DESCRIPTION
When crafted car key `fromTempBlueprint == null`.
If hook `OnItemCraft` return bool, will NRE and crash client on error `RPC Error in RPC_RequestAddLock`