### PR TITLE
Improving user language support.

### DIFF
--- a/src/RustCommands.cs
+++ b/src/RustCommands.cs
@@ -232,8 +232,7 @@ namespace Oxide.Game.Rust
             else
             {
                 // TODO: Check if language exists before setting, warn if not
-                string[] languages = lang.GetLanguages();
-                if (languages.Contains(args[0]))
+                if (args[0].Length == 2)
                 {
                     lang.SetLanguage(args[0], player.Id);
                 }

--- a/src/RustCommands.cs
+++ b/src/RustCommands.cs
@@ -231,13 +231,14 @@ namespace Oxide.Game.Rust
             }
             else
             {
+                var lang = args[0].ToLower();
                 // TODO: Check if language exists before setting, warn if not
-                if (args[0].Length == 2)
+                if (lang.Length == 2 && Regex.IsMatch(lang, @"^[a-z]+$"))
                 {
-                    lang.SetLanguage(args[0], player.Id);
+                    lang.SetLanguage(lang, player.Id);
                 }
 
-                player.Reply(string.Format(lang.GetMessage("PlayerLanguage", this, player.Id), args[0]));
+                player.Reply(string.Format(lang.GetMessage("PlayerLanguage", this, player.Id), lang));
             }
         }
 

--- a/src/RustCommands.cs
+++ b/src/RustCommands.cs
@@ -232,7 +232,6 @@ namespace Oxide.Game.Rust
             else
             {
                 var lang = args[0].ToLower();
-                // TODO: Check if language exists before setting, warn if not
                 if (lang.Length == 2 && Regex.IsMatch(lang, @"^[a-z]+$"))
                 {
                     lang.SetLanguage(lang, player.Id);


### PR DESCRIPTION
By default Oxide only allow to change your language to an existing language folder meaning that the user language will never be supported if the user sets his language before a plug-in supporting his language is installed (except if he try again to sets his language).

My change will provide the user language as soon as the user sets his language and a plug-in supports it. No error will be caused since if the language is not supported then Oxide returns the English version by default.

I added a basic condition to avoid weird language.