### PR TITLE
Add OnNetworkSubscriptionsGather hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -18611,6 +18611,34 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnNetworkSubscriptionsGather",
+            "HookName": "OnNetworkSubscriptionsGather",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NetworkVisibilityGrid",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "GetVisibleFrom",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Network.Visibility.Group",
+                "System.Collections.Generic.List`1<Network.Visibility.Group>",
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "T3GfXROur+F4qwSy2RcYQavQBrw411u1ucN04HNNPM8=",
+            "BaseHookName": null,
+            "HookCategory": "Network"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
object OnNetworkSubscriptionsGather(NetworkVisibilityGrid grid, Network.Visibility.Group group, List<Network.Visibility.Group> groups, int radius)
```
- Called when determining which network groups to subscribe a player to in a given radius
- Returning non-null will cancel the default behavior