### PR TITLE
Fix CultureNotFoundException

### DIFF
--- a/src/Libraries/Player.cs
+++ b/src/Libraries/Player.cs
@@ -23,7 +23,19 @@ namespace Oxide.Game.Rust.Libraries
         /// <summary>
         /// Gets the player's language
         /// </summary>
-        public CultureInfo Language(BasePlayer player) => CultureInfo.GetCultureInfo(player.net.connection.info.GetString("global.language") ?? "en");
+        public CultureInfo Language(BasePlayer player)
+        {
+            CultureInfo cultureInfo;
+            try
+            {
+                cultureInfo = CultureInfo.GetCultureInfo(player.net.connection.info.GetString("global.language", "") ?? "en");
+            }
+            catch (CultureNotFoundException)
+            {
+                cultureInfo = CultureInfo.GetCultureInfo("en");
+            }
+            return cultureInfo;
+        }
 
         /// <summary>
         /// Gets the player's IP address


### PR DESCRIPTION
If player has selected the _"Pirate"_ Language, the _CultureNotFoundException_ will be thrown, when plugin tries to access player's _CultureInfo_.

`Failed to run <...> (CultureNotFoundException: Culture name en-PT is not supported.
Parameter name: name)
  at System.Globalization.CultureInfo..ctor (System.String name, System.Boolean useUserOverride, System.Boolean read_only) [0x00073] in <fb001e01371b4adca20013e0ac763896>:0
  at System.Globalization.CultureInfo.GetCultureInfo (System.String name) [0x00038] in <fb001e01371b4adca20013e0ac763896>:0
  at Oxide.Game.Rust.Libraries.Player.Language (BasePlayer player) [0x00023] in <2ef4a134cfaf41c9bbcaa0c9dbd896d7>:0
  at Oxide.Game.Rust.Libraries.Covalence.RustPlayer.get_Language () [0x00019] in <2ef4a134cfaf41c9bbcaa0c9dbd896d7>:0
 <...>
`