### PR TITLE
Add OnInventoryItems[Count|Take] hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -19198,6 +19198,60 @@
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 4,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryItemsCount",
+            "HookName": "OnInventoryItemsCount",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GetAmount",
+              "ReturnType": "System.Int32",
+              "Parameters": [
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "cPr7MD/SwKmak+prSQj9ufDcYKKVOknvhCI/PSXPnn8=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryItemsTake",
+            "HookName": "OnInventoryItemsTake",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Take",
+              "ReturnType": "System.Int32",
+              "Parameters": [
+                "System.Collections.Generic.List`1<Item>",
+                "System.Int32",
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "XQhkr56LFim15MiRXRj4uYXB7vVw7iChnHqABFnnlQM=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
object OnInventoryItemsCount(PlayerInventory inventory, int itemid)
```

- Called when the `PlayerInventory.GetAmount(int itemid)` method is called
- Returning an `int` will cancel the default counting, and consider that value the count result

```cs
object OnInventoryItemsTake(PlayerInventory inventory, List<Item> collect, int itemid, int amount)
```

- Called when the `PlayerInventory.Take(List<Item> collect, int itemid, int amount)` method is called
- Returning an `int` will cancel the default taking, and consider that value the number taken

Using these hooks allows centrally overriding the item cost for a variety of situations, including: placing blocks, upgrading blocks, repairing blocks, repairing items, crafting car keys, unlocking tech tree nodes, and purchasing vehicles. Possible use cases include: changing the cost amount of certain resources, and pulling items from containers external to the player.

The downside to this approach is that only one plugin can override the cost, so if multiple plugins want to provide item sources (e.g., Item Puller sourcing from nearby boxes, and Backpacks/Bank sourcing from the player's remote container), then those plugins have to communicate amongst each other to work out the conflict.