### PR TITLE
Add OnInventory[Items|Ammo]Find hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -19252,6 +19252,59 @@
             "BaseHookName": null,
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryItemsFind",
+            "HookName": "OnInventoryItemsFind",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "FindItemIDs",
+              "ReturnType": "System.Collections.Generic.List`1<Item>",
+              "Parameters": [
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "33gTbFbp0Rbw9096Nk+j2SVjbmJxsQt9NLeyz50ajAE=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryAmmoFind",
+            "HookName": "OnInventoryAmmoFind",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "FindAmmo",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Collections.Generic.List`1<Item>",
+                "Rust.AmmoTypes"
+              ]
+            },
+            "MSILHash": "/4NWOtHEnUP/VVzQ3FWBpYpPnCJDQd6TzKcm2j3trJM=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
List<Item> OnInventoryItemsFind(PlayerInventory inventory, int itemid)
```
- Called when the `PlayerInventory.FindItemIDs(int itemid)` method is called, which happens when reloading a weapon, switching ammo type, unlocking a key lock, unlocking a car key lock, and when purchasing an item at a vending machine or vendor
- Returning a `List<Item>` value cancels the default behavior, and causes `PlayerInventory.FindItemIDs(int itemid)` to return that value
```cs
void OnInventoryAmmoFind(PlayerInventory inventory, List<Item> list, AmmoTypes ammoType)
```
- Called when the `PlayerInventory.FindAmmo(List<Item> list, AmmoTypes ammoType)` method is called, which happens when reloading or switching ammo with certain weapons
- Returning non-null cancels the default behavior, allowing the plugin to populate the list another way