### PR TITLE
Add OnDroppedItemCombined hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -19276,6 +19276,32 @@
             "BaseHookName": null,
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 187,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 1,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnDroppedItemCombined",
+            "HookName": "OnDroppedItemCombined",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "DroppedItem",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnDroppedOn",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "DroppedItem"
+              ]
+            },
+            "MSILHash": "xPEzYttM7mW8A95SZ687gJIvUelXBJ8mqUYxDx0+mB0=",
+            "BaseHookName": "CanCombineDroppedItem [patch 1]",
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
void OnDroppedItemCombined(DroppedItem droppedItem)
```
Called after a dropped item has been combined with another. Useful for resetting removal time of the remaining item after vanilla has changed it. Existing plugins which use the pre hook to reset removal time should ideally switch to this post hook.