### PR TITLE
Add OnRCUpdateIdentifier hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -20010,6 +20010,33 @@
             "BaseHookName": "OnCollectiblePickup [deprecated 1]",
             "HookCategory": "Resource"
           }
+        },
+		{
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnRCUpdateIdentifier",
+            "HookName": "OnRCUpdateIdentifier",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PoweredRemoteControlEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "UpdateIdentifier",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "vwY0NpE5JAbX4mnxVg7X23KWC+sO6nWMyVN086sQiJY=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnRCUpdateIdentifier(PoweredRemoteControlEntity entity, string newID, bool clientSend)
```

- Allows cancelling RC identifier update by returning non-null value