### PR TITLE
Added Recreate property for new UI functionality

### DIFF
--- a/src/RustCui.cs
+++ b/src/RustCui.cs
@@ -193,6 +193,9 @@ namespace Oxide.Game.Rust.Cui
         [JsonProperty("parent")]
         public string Parent { get; set; }
 
+        [JsonProperty("destroyUI") JsonProperty(NullValueHandling=NullValueHandling.Ignore)]
+        public bool Recreate { get; set; }
+
         [JsonProperty("components")]
         public List<ICuiComponent> Components { get; } = new List<ICuiComponent>();
 


### PR DESCRIPTION
https://github.com/Facepunch/Rust.Community/pull/40 is set to be added on force wipe, adding a new property to the panel if the key gets added the existing element gets destroyed (if it exists), this basically just saves a DestroyUI call.

i added the NullValueHandling Attribute since the pull request uses ContainsKey instead of GetBoolean, feel free to alter this if there is a better way of doing this