### PR TITLE
OnMessagePlayer hook for Oxide.Game.Rust.Libraries.Player library

### DIFF
--- a/src/Libraries/Player.cs
+++ b/src/Libraries/Player.cs
@@ -381,7 +381,7 @@ namespace Oxide.Game.Rust.Libraries
 
             message = args.Length > 0 ? string.Format(Formatter.ToUnity(message), args) : Formatter.ToUnity(message);
             string formatted = prefix != null ? $"{prefix} {message}" : message;
-            if (Interface.CallHook("OnMessagePlayer", text, formatted, userId) != null)
+            if (Interface.CallHook("OnMessagePlayer", formatted, player, userId) != null)
 			{
 				return;
 			}

--- a/src/Libraries/Player.cs
+++ b/src/Libraries/Player.cs
@@ -381,6 +381,10 @@ namespace Oxide.Game.Rust.Libraries
 
             message = args.Length > 0 ? string.Format(Formatter.ToUnity(message), args) : Formatter.ToUnity(message);
             string formatted = prefix != null ? $"{prefix} {message}" : message;
+            if (Interface.CallHook("OnMessagePlayer", text, formatted, userId) != null)
+			{
+				return;
+			}
             player.SendConsoleCommand("chat.add", 2, userId, formatted);
         }
 


### PR DESCRIPTION
This hook already exists in the game itself, on BasePlayer.ChatMessage method So I think it would make sense to call the same hook in the method, that does pretty much the same thing