### PR TITLE
OnAmmoSwitch missing newAmmo

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -4613,7 +4613,7 @@
             "InjectionIndex": 40,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, l0",
+            "ArgumentString": "this, l0, l2",
             "HookTypeName": "Simple",
             "Name": "OnAmmoSwitch",
             "HookName": "OnAmmoSwitch",


### PR DESCRIPTION
extended Hook-parameters with ItemDefinition itemDefinition
