### PR TITLE
Add CanExplosiveStick hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -18922,6 +18922,29 @@
             "MSILHash": "DmCDxDoSW5Q9I8alhw+1h2SI1/s7I6Paxl0pHypRl88=",
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "HookTypeName": "Simple",
+            "Name": "CanExplosiveStick",
+            "HookName": "CanExplosiveStick",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TimedExplosive",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanStickTo",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BaseEntity"
+              ]
+            },
+            "MSILHash": "Jyke1BlU5xRjfvIHgO36zfw+LDLsElJfz0G7mrgbxhs="
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
### Purpose
To bring back C4 drones.

### Usage
```cs
object CanExplosiveStick(TimedExplosive explosive, Drone drone) => true;
```

### Method being hooked
```cs
public virtual bool CanStickTo(BaseEntity entity)
{
    object obj = Interface.CallHook("CanExplosiveStick", this, entity);
    if (obj is bool)
    {
        return (bool)obj;
    }
    if (entity.TryGetComponent<DecorDeployable>(out var _))
    {
        return false;
    }
    if (entity is Drone)
    {
        return false;
    }
    return true;
}
```