### PR TITLE
Add OnInventoryAmmoItemFind hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -18922,6 +18922,50 @@
             "MSILHash": "DmCDxDoSW5Q9I8alhw+1h2SI1/s7I6Paxl0pHypRl88=",
             "HookCategory": "Vehicle"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 8,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0.inventory, this.fuelType",
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryAmmoItemFind",
+            "HookName": "OnInventoryAmmoItemFind",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Chainsaw",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GetAmmo",
+              "ReturnType": "Item",
+              "Parameters": []
+            },
+            "MSILHash": "y8/5tiF5Dh3aKchhdreYMGATnJGV/W6lBvsWNlmj3aY="
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 8,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0.inventory, this.fuelType",
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryAmmoItemFind",
+            "HookName": "OnInventoryAmmoItemFind",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "FlameThrower",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GetAmmo",
+              "ReturnType": "Item",
+              "Parameters": []
+            },
+            "MSILHash": "rANwqSs1DJQ+CbqH2xLKAbn1FRHd2tr1sNyx+7vxrr4="
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
Item OnInventoryAmmoItemFind(PlayerInventory inventory, ItemDefinition itemDefinition)
```
- Called when reloading a `Chainsaw` or `FlameThrower`
- Returning an `Item` makes the weapon reload with that item instead of looking in the player inventory

This is similar to the existing hook `object OnInventoryAmmoFind(PlayerInventory inventory, List<Item> collect, AmmoTypes ammoType)`, but returns a single item.