### PR TITLE
Add param to OnRidableAnimalClaim hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -12062,10 +12062,10 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 8,
+            "InjectionIndex": 24,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, l0",
+            "ArgumentString": "this, l0, l2",
             "HookTypeName": "Simple",
             "Name": "OnRidableAnimalClaim",
             "HookName": "OnRidableAnimalClaim",
@@ -12087,7 +12087,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 50,
+            "InjectionIndex": 55,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l0",


### PR DESCRIPTION
Update the `OnRidableAnimalClaim` hook to accept a 3rd param, for the saddle item used. This allows plugins to detect whether the player attempted to claim the horse with a single or double saddle, in case they want to override the behavior. For example, the Vehicle Vendor Options plugin has a permission to allow claiming horses for free by not consuming the saddle item.

```cs
object OnRidableAnimalClaim(RidableHorse horse, BasePlayer player, Item saddleItem)
```

Code being hooked:
```cs
public void RPC_Claim(RPCMessage msg)
{
    BasePlayer player = msg.player;
    if (!(player == null) && IsForSale())
    {
        int tokenItemID = msg.read.Int32();
        Item item = GetPurchaseToken(player, tokenItemID);
        if (item != null && Interface.CallHook("OnRidableAnimalClaim", this, player, item) == null)
        {
            SetFlag(Flags.Reserved2, b: false);
            OnClaimedWithToken(item);
            item.UseItem();
            Facepunch.Rust.Analytics.Server.VehiclePurchased(base.ShortPrefabName);
            Facepunch.Rust.Analytics.Azure.OnVehiclePurchased(msg.player, this);
            AttemptMount(player, doMountChecks: false);
            Interface.CallHook("OnRidableAnimalClaimed", this, player);
        }
    }
}
```

Notes:
- The `OnRidableAnimalClaim` hook is now called after vanilla has verified that the horse is for sale and that the saddle item is valid. I doubt this will cause any problems.
- The `OnRidableAnimalClaimed` hook has been moved to the end of the method, same as before the force wipe.