### PR TITLE
OnWireConnect hook fix & removal of the patch that nulls out linePoints

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7469,7 +7469,7 @@
             "InjectionIndex": 167,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "l0, l8, l4, l10, l6",
+            "ArgumentString": "l0, l8, l4, l10, l6, l2",
             "HookTypeName": "Simple",
             "Name": "OnWireConnect",
             "HookName": "OnWireConnect",
@@ -7539,60 +7539,6 @@
             },
             "MSILHash": "BC7XeILwaz/7J9n1q0QqQAYo8676z9e6HZuGEBHzfmM=",
             "HookCategory": "Player"
-          }
-        },
-        {
-          "Type": "Modify",
-          "Hook": {
-            "InjectionIndex": 178,
-            "RemoveCount": 0,
-            "Instructions": [
-              {
-                "OpCode": "ldloc_s",
-                "OpType": "Variable",
-                "Operand": 11
-              },
-              {
-                "OpCode": "ldfld",
-                "OpType": "Field",
-                "Operand": "Assembly-CSharp|IOEntity|outputs"
-              },
-              {
-                "OpCode": "ldloc_s",
-                "OpType": "Variable",
-                "Operand": 6
-              },
-              {
-                "OpCode": "ldelem_ref",
-                "OpType": "None"
-              },
-              {
-                "OpCode": "ldnull",
-                "OpType": "None"
-              },
-              {
-                "OpCode": "stfld",
-                "OpType": "Field",
-                "Operand": "Assembly-CSharp|IOEntity/IOSlot|linePoints"
-              }
-            ],
-            "HookTypeName": "Modify",
-            "Name": "OnWireConnect [patch]",
-            "HookName": "OnWireConnect",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "WireTool",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "MakeConnection",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "koexvF/Pf6UBEpJ2fWbEp2RXC54/9n1WKVftlwUhv/Y=",
-            "BaseHookName": "OnWireConnect",
-            "HookCategory": "_Patches"
           }
         },
         {


### PR DESCRIPTION
So as it turns out, after April 2023 Rust update, linePoints are assigned to the output IOentity AFTER calling the OnWireConnect hook. Mr. Blue suggested adding an argument that passes the list of linePoints to the hook call so the subscribed method can process it for whatever reason. Before April 2023, the method could just take outputEntity[outputSlot].linePoints, so this quick and dirty solution should help. It won't break anything if your hook subscription doesn't use it, since it's the last argument). Mr. Blue also agreed with me that removing the patch named "OnWireConnect [patch]" which added nulling out of the linePoints if the hook returned non-null - now the linePoints are assigned to the output entity afterwards, so it's not necessary - since nothing would get assigned in case of returning non.null.