### PR TITLE
Create Hook OnLogInvalidAttack

### DIFF
--- a/src/Oxide.Rust.csproj
+++ b/src/Oxide.Rust.csproj
@@ -58,7 +58,7 @@
     <PatchedFiles Include="$(TargetDir)\Assembly-CSharp.dll; $(TargetDir)\Facepunch.Console.dll; $(TargetDir)\Facepunch.Network.dll; $(TargetDir)\Facepunch.Rcon.dll; $(TargetDir)\Facepunch.Sqlite.dll; $(TargetDir)\Facepunch.UnityEngine.dll" />
   </ItemGroup>
   <Target Name="AddGitBranchMeta" BeforeTargets="CoreGenerateAssemblyInfo">
-    <Exec Command="git rev-parse --abbrev-ref HEAD" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="True">
+    <Exec Command="git name-rev --name-only HEAD" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="True">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitBranch"/>
     </Exec>
     <ItemGroup>

--- a/src/RustCommands.cs
+++ b/src/RustCommands.cs
@@ -706,7 +706,8 @@ namespace Oxide.Game.Rust
         {
             if (player.IsServer)
             {
-                player.Reply("Oxide.Rust Version: " + RustExtension.AssemblyVersion);
+                string format = "Oxide.Rust Version: {0}\nOxide.Rust Branch: {1}";
+                player.Reply(string.Format(format, RustExtension.AssemblyVersion, RustExtension.AssemblyBranch));
             }
             else
             {


### PR DESCRIPTION
The OnPlayerAttack hook is so late that any invalid attacks can't be perceived by a plugin can we add a hook for :
OnLogInvalidAttack(Hitinfo hitinfo, string description)

`    public void LogInvalid(HitInfo info, string description)
    {
        this.Log(info.Initiator, info.Weapon, info.HitEntity as BaseCombatEntity, description, info.ProjectilePrefab, info.ProjectileID, -1f, info);
         if (Interface.CallHook("OnLogInvalidAttack", hitInfo, description) != null)
        {
            return;
        }
    }
        `