### PR TITLE
Add altMove parameter to CanMoveItem

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3410,7 +3410,7 @@
             "InjectionIndex": 35,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "l5, this, l1, l2, l3",
+            "ArgumentString": "l5, this, l1, l2, l3, l4",
             "HookTypeName": "Simple",
             "Name": "CanMoveItem",
             "HookName": "CanMoveItem",


### PR DESCRIPTION
```csharp
object CanMoveItem(Item item, PlayerInventory playerLoot, ItemContainerId targetContainer, int targetSlot, int amount, bool altMove)
```
altMove is true when using alt+right-click to directly equip clothing items. Required now for GetIdealContainer(), GiveItem() and GetIdealPickupContainer()