### PR TITLE
Exposing BuildingBlock::playerCustomColourToApply for modding

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -46053,7 +46053,7 @@
           },
           "MSILHash": ""
         },
-		{
+        {
           "Name": "BuildingBlock::playerCustomColourToApply",
           "AssemblyName": "Assembly-CSharp.dll",
           "TypeName": "BuildingBlock",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -46052,6 +46052,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+		{
+          "Name": "BuildingBlock::playerCustomColourToApply",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BuildingBlock",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "playerCustomColourToApply",
+            "FullTypeName": "System.UInt32 BuildingBlock::playerCustomColourToApply",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [


### PR DESCRIPTION
This field is used to set the custom color for the new container skin and likely future skins.