### PR TITLE
Add OnPatrolHelicopterTakeDamage hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -19700,6 +19700,31 @@
             },
             "MSILHash": "GmjYIqIW4D8C6nSJdJj6kHL6vWcrHcDl4k41KBXk0Hg="
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": "",
+            "HookTypeName": "Simple",
+            "Name": "OnPatrolHelicopterTakeDamage",
+            "HookName": "OnPatrolHelicopterTakeDamage",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PatrolHelicopter",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Hurt",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "HitInfo"
+              ]
+            },
+            "MSILHash": "eqmrk1cs/LjuiXQJ+nBw142N/5BaJ8i+unxJ7/AIP0M=",
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```csharp
object OnPatrolHelicopterTakeDamage(PatrolHelicopter heli, HitInfo hitinfo)
```
Called when the Patrol Helicopter takes damage

This functionality cannot be replicated with OnEntityTakeDamage due to the way Patrol Helicopter deaths occur. That hook calls too late, and the helicopter is considered dead (heli.myAI.IsDead) on the final hit, even though it is not. This means you cannot accurately track total damage received during its pre-death state, or check when the final hit actually occurs, in order to get the killer.