### PR TITLE
OnCoalingTowerBeginUnload and OnCoalingTowerUnload Hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -19791,6 +19791,54 @@
             "MSILHash": "eqmrk1cs/LjuiXQJ+nBw142N/5BaJ8i+unxJ7/AIP0M=",
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 121,
+            "ReturnBehavior": 3,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l13 => l13",
+            "HookTypeName": "Simple",
+            "Name": "OnCoalingTowerUnload",
+            "HookName": "OnCoalingTowerUnload",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "CoalingTower",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "EmptyTenPercent",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "WKcAMSehLVw6QkaTKXlvgDM+JjR6Zp5ipw/gwLIzYcc=",
+            "HookCategory": "Resource"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnCoalingTowerBeginUnload",
+            "HookName": "OnCoalingTowerBeginUnload",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "CoalingTower",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "RPC_Unload",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "gEb1ELb/bsqFL+Zc2QqgwATuXg+i3vkKE2/ZigjGsEM=",
+            "HookCategory": "Resource"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
I'm not sure if what I did was the best option, because OnCoalingTowerBeginUnload is called before an actual attempt to unload happened.
OnCoalingTowerUnload can't exit due to the fact that it's in the middle of a iteration of polled list. There might be a better way but I wasn't able to fine one.

I need to know who began unloading and what resources being unloaded at the moment