### PR TITLE
Fixing NPE issue of OnPlayerSpawn hook when caller returns non-null

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -9623,7 +9623,7 @@
                 "Operand": 13
               },
               {
-                "OpCode": "ldnull",
+                "OpCode": "ldloc_1",
                 "OpType": "None"
               },
               {


### PR DESCRIPTION
Fixing NPE issue of OnPlayerSpawn hook when caller returns non-null

Forum Post Link:
https://umod.org/community/hooks-extended/51527-onplayerspawn-hook-bug-npe?page=1#post-1

Context:
OnPlayerSpawn hook call returns null to the caller if return value is not-null. This will always cause NPE and a player will not be able to spawn onto the server.

In order to allow for SpawnNewPlayer default behavior modifications, BasePlayer needs to be returned instead.

Let me know if you need test evidence.
