### PR TITLE
Added Hook "CanDropBackpack"

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -17985,6 +17985,30 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 9,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l0.contents, this",
+            "HookTypeName": "Simple",
+            "Name": "CanDropBackpack",
+            "HookName": "CanDropBackpack",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "TryDropBackpack",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "ogPLODIcNBZEZ/Su5e4sakg2XXga+cVxJ1hfqszaSO8=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 171,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 1,


### PR DESCRIPTION
The hook prevents the backpack from falling out in the Wounded, Crawling, or Dead states.

Upon death, it will still drop if the backpack is not empty, due to the CanAcceptItem check. By changing containerVolumeWhenFilled to zero for ItemModBackpack, you can allow the backpack to move through containers, even if it is not empty.

The hook is also needed to access the backpack when dying, as the backpack will fall out before the OnPlayerDeath hook is triggered.