### PR TITLE
Add OnNearbyTurretsScan hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -19945,6 +19945,63 @@
             "BaseHookName": "OnPatrolHelicopterTakeDamage",
             "HookCategory": "Entity"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 2,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnNearbyTurretsScan"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldloc_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "box",
+                "OpType": "Type",
+                "Operand": "mscorlib|System.Boolean"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "brtrue_s",
+                "OpType": "Instruction",
+                "Operand": 10
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnNearbyTurretsScan",
+            "HookName": "OnNearbyTurretsScan",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "AutoTurret",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "UpdateNearbyTurrets",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "vZ3Q84yEKDxy1jdMTwOBDTEiYuNd+ZO8iIMZobA8CZo=",
+            "HookCategory": "Turret"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
```cs
object OnNearbyTurretsScan(AutoTurret turret, List<AutoTurret> nearbyTurrets, bool created)
{
    LogWarning($"OnNearbyTurretsScan works!");
    return null;
}
```

- Called when an auto turret spawns or despawns, in order to determine which turrets are nearby
- Returning non-null will cancel the default Vis.Entities call, allowing for an alternative searching implementation
- The list that will be populated with the Vis.Entities call is passed to the hook, so plugins can simply use a `void` return type and add additional turrets that may not be found by the Vis.Entities call, such as turrets that don't have a collider on the Deployed layer (e.g., for Car Turrets or Drone Turrets)
- Works similar to the `OnSamSiteTargetScan` hook