### PR TITLE
Added object OnQuarryToggle(MiningQuarry quarry, BasePlayer player) hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7572,6 +7572,38 @@
                 "Operand": 10
               },
               {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnQuarryToggle"
+              },
+              {
+                "OpCode": "ldloc_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|BaseEntity/RPCMessage|player"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "ldnull",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "bne_un_s",
+                "OpType": "Instruction",
+                "Operand": 10
+              },
+              {
                 "OpCode": "ldloc_0",
                 "OpType": "None"
               },
@@ -7638,6 +7670,38 @@
             "Instructions": [
               {
                 "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 10
+              },
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnQuarryToggle"
+              },
+              {
+                "OpCode": "ldloc_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|BaseEntity/RPCMessage|player"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "ldnull",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "bne_un_s",
                 "OpType": "Instruction",
                 "Operand": 10
               },


### PR DESCRIPTION
Tested and working

```c#
[MaxDistance(3f)]
[RPC_Server]
public void StartEngine(BaseEntity.RPCMessage msg)
{
    MiningQuarry parentEntity = base.GetParentEntity() as MiningQuarry;
    if (parentEntity && Interface.CallHook("OnQuarryToggle", parentEntity, msg.player) == null)
    {
        parentEntity.EngineSwitch(true);
        Interface.CallHook("OnQuarryToggled", parentEntity, msg.player);
    }
}

[MaxDistance(3f)]
[RPC_Server]
public void StopEngine(BaseEntity.RPCMessage msg)
{
    MiningQuarry parentEntity = base.GetParentEntity() as MiningQuarry;
    if (parentEntity && Interface.CallHook("OnQuarryToggle", parentEntity, msg.player) == null)
    {
        parentEntity.EngineSwitch(false);
        Interface.CallHook("OnQuarryToggled", parentEntity, msg.player);
    }
}
```