### PR TITLE
Add OnItemFilter hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -20099,6 +20099,32 @@
             "MSILHash": "4UX5r03EqmiQCKgp0C9qRR44ntx2+fpTkb4/sfJaUwA=",
             "HookCategory": "NPC"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnItemFilter",
+            "HookName": "OnItemFilter",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "StorageContainer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ItemFilter",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "Item",
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "RIrUvYG2k9omvKx8rKGlOVjmWOTQIUold950HrIb03M=",
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Added
`object OnItemFilter(StorageContainer container, Item item, int targetSlot)
{
    return null;
}`

Called before check property onlyAcceptCategory in StorageContainer.
Returning true or false overrides default behavior.