### PR TITLE
Add support new gametags

### DIFF
--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -630,10 +630,10 @@ namespace Oxide.Game.Rust
         private void OnServerInformationUpdated()
         {
             // Add Steam tags for Oxide
-            SteamServer.GameTags += $",{ServerTagCompressor.TagPrefixCharacter}o";
+            SteamServer.GameTags += ",^o";
             if (Interface.Oxide.Config.Options.Modded)
             {
-                SteamServer.GameTags += $"{ServerTagCompressor.TagPrefixCharacter}z";
+                SteamServer.GameTags += "^z";
             }
         }
 

--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -630,10 +630,10 @@ namespace Oxide.Game.Rust
         private void OnServerInformationUpdated()
         {
             // Add Steam tags for Oxide
-            SteamServer.GameTags += ",^o";
+            SteamServer.GameTags += $",{ServerTagCompressor.TagPrefixCharacter}o";
             if (Interface.Oxide.Config.Options.Modded)
             {
-                SteamServer.GameTags += "^z";
+                SteamServer.GameTags += $"{ServerTagCompressor.TagPrefixCharacter}z";
             }
         }
 

--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -630,10 +630,10 @@ namespace Oxide.Game.Rust
         private void OnServerInformationUpdated()
         {
             // Add Steam tags for Oxide
-            SteamServer.GameTags += ",oxide";
+            SteamServer.GameTags += ",^o";
             if (Interface.Oxide.Config.Options.Modded)
             {
-                SteamServer.GameTags += ",modded";
+                SteamServer.GameTags += "^z";
             }
         }
 


### PR DESCRIPTION
In the upcoming Rust update changed game tags.

Class **ServerTagCompressor**
```cs
	// Token: 0x0400002F RID: 47
	private static readonly IReadOnlyDictionary<char, string> charToTag = new Dictionary<char, string>
	{
		{ 'b', "biweekly" },
		{ 'c', "creative" },
		{ 'd', "training" },
		{ 'e', "minigame" },
		{ 'g', "gamemode" },
		{ 'h', "hardcore" },
		{ 'i', "battlefield" },
		{ 'j', "broyale" },
		{ 'k', "builds" },
		{ 'm', "monthly" },
		{ 'o', "oxide" },
		{ 'p', "pve" },
		{ 'r', "roleplay" },
		{ 's', "softcore" },
		{ 't', "tut" },
		{ 'v', "vanilla" },
		{ 'w', "weekly" },
		{ 'y', "carbon" },
		{ 'z', "modded" }
	};

	// Token: 0x04000031 RID: 49
	public static readonly char TagPrefixCharacter = '^';
