### PR TITLE
Adding hooks to track deploy and recall of ScientistNPC by BradleyAPC.

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -20761,6 +20761,85 @@
             "BaseHookName": "OnStructureUpgrade [Delayed]",
             "HookCategory": "Structure"
           }
+        },
+{
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 122,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnBradleyScientistInitialized [BradleyAPC]",
+            "HookName": "OnBradleyScientistInitialized",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BradleyAPC",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "InitScientist",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ScientistNPC",
+                "UnityEngine.Vector3",
+                "BasePlayer",
+                "System.Boolean",
+                "System.Boolean"
+              ]
+            },
+            "MSILHash": "1TbHAd27cEn42xidJjKldd3qAEbDOzHhEluOfklvJ14=",
+            "HookCategory": "NPC"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 3,
+            "HookTypeName": "Simple",
+            "Name": "OnBradleyScientistRecalled [BradleyAPC]",
+            "HookName": "OnBradleyScientistRecalled",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BradleyAPC",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnScientistMounted",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ScientistNPC"
+              ]
+            },
+            "MSILHash": "yl9aYgR/KvsKEHdrLPDJa4SZrGnMINPqmslBjj5yUmQ=",
+            "HookCategory": "NPC"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "HookTypeName": "Simple",
+            "Name": "CanBradleyDeployScientists [BradleyAPC]",
+            "HookName": "CanBradleyDeployScientists",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BradleyAPC",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "CanDeployScientists",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BaseEntity",
+                "System.Collections.Generic.List`1<GameObjectRef>",
+                "System.Collections.Generic.List`1<UnityEngine.Vector3>"
+              ]
+            },
+            "MSILHash": "yJmG0f32C9+J7trNHLN4AdU4ilMblTied3qOVWzbdog=",
+            "HookCategory": "NPC"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Adding hooks to track deploy and recall of ScientistNPC by BradleyAPC.

`object CanBradleyDeployScientists(BradleyAPC bradley, BasePlayer attacker, List<GameObjectRef> scientistPrefabs, List<Vector3> spawnPositions)` - Called when attempting to deploy ScientistNPCs from BradleyAPC. Returning true or false overrides default behavior.

`void OnBradleyScientistInitialized(BradleyAPC bradley, ScientistNPC scientist, Vector3 spawnPos)` - Called when a ScientistNPC is deployed(spawned) from the BradleyAPC and has a target, if the target is not null. No return behavior.

`void OnBradleyScientistRecalled(BradleyAPC bradley, ScientistNPC scientist)` - Called when a ScientistNPC is recalled into the BradleyAPC. No return behavior.