### PR TITLE
Add OnVendingShopOpen[ed] hook for TravellingVendor

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -20761,6 +20761,57 @@
             "BaseHookName": "OnStructureUpgrade [Delayed]",
             "HookCategory": "Structure"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 9,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this.vendingMachine, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnVendingShopOpen [TravellingVendor]",
+            "HookName": "OnVendingShopOpen",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TravellingVendor",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "SV_OpenMenu",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "+fMEg4NkvoineQ31ZC5YloROL/KR9/Zg+FppE5WD9PM=",
+            "HookCategory": "Vending"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 23,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this.vendingMachine, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnVendingShopOpened [TravellingVendor]",
+            "HookName": "OnVendingShopOpened",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TravellingVendor",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "SV_OpenMenu",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "+fMEg4NkvoineQ31ZC5YloROL/KR9/Zg+FppE5WD9PM=",
+            "BaseHookName": "OnVendingShopOpen [TravellingVendor]",
+            "HookCategory": "Vending"
+          }
         }
       ],
       "Modifiers": [
@@ -47334,7 +47385,7 @@
           "TypeName": "ZiplineLaunchPoint",
           "Type": 1,
           "TargetExposure": [
-            0
+            2
           ],
           "Flagged": false,
           "Signature": {
@@ -51351,6 +51402,158 @@
             ],
             "Name": "hasSidecar",
             "FullTypeName": "System.Boolean Bike::hasSidecar",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "TravellingVendor::vendingMachine",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "TravellingVendor",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "vendingMachine",
+            "FullTypeName": "NPCVendingMachine TravellingVendor::vendingMachine",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "PuzzleReset::resetTimeElapsed",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "PuzzleReset",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "resetTimeElapsed",
+            "FullTypeName": "System.Single PuzzleReset::resetTimeElapsed",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "TerrainPath::MainRoads",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "TerrainPath",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              3
+            ],
+            "Name": "MainRoads",
+            "FullTypeName": "System.Collections.Generic.List`1<PathList> TerrainPath::MainRoads",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "TerrainPath::SideRoads",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "TerrainPath",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              3
+            ],
+            "Name": "SideRoads",
+            "FullTypeName": "System.Collections.Generic.List`1<PathList> TerrainPath::SideRoads",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "TerrainPath::TrailRoads",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "TerrainPath",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              3
+            ],
+            "Name": "TrailRoads",
+            "FullTypeName": "System.Collections.Generic.List`1<PathList> TerrainPath::TrailRoads",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "Recycler::scrapRemainder",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "Recycler",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "scrapRemainder",
+            "FullTypeName": "System.Single Recycler::scrapRemainder",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "Bike::carPhysics",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "Bike",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "carPhysics",
+            "FullTypeName": "CarPhysics`1<Bike> Bike::carPhysics",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "Bike::timeSinceLastUsed",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "Bike",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "timeSinceLastUsed",
+            "FullTypeName": "TimeSince Bike::timeSinceLastUsed",
             "Parameters": []
           },
           "MSILHash": ""


### PR DESCRIPTION
- Add `object OnVendingShopOpen(VendingMachine, BasePlayer)` hook to `TravellingVendor` class
- Add `void OnVendingShopOpened(VendingMachine, BasePlayer)` hook to `TravellingVendor` class
- Expose various fields/methods as public
  - `Bike::carPhysics`
  - `Bike::timeSinceLastUsed`
  - `PuzzleReset::resetTimeElapsed`
  - `Recycler::scrapRemainder`
  - `TerrainPath::MainRoads`
  - `TerrainPath::SideRoads`
  - `TerrainPath::TrailRoads`
  - `TravellingVendor::vendingMachine`
  - `ZiplineLaunchPoint::CalculateZiplinePoints`