### PR TITLE
Using new pluginID field instead of skinID, for modified entites.

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -51377,6 +51377,13 @@
           "TypeName": "SprayCanSpray",
           "FieldType": "mscorlib|System.Int32",
           "Flagged": false
+        },
+        {
+          "Name": "pluginID",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseEntity",
+          "FieldType": "mscorlib|System.UInt64",
+          "Flagged": false
         }
       ]
     },


### PR DESCRIPTION
Hello, I suggest adding a field named pluginID (the name can be changed).

Currently, there are many plugins that use the skinID field for modified entities to mark and/or link them to a plugin.
This is very convenient for other plugins to identify them, but it’s not always possible to specify the plugin's "id" in the skinID. For example, those entities that have skins use this field, and it cannot be used for such purposes.

https://umod.org/community/rust/53529-skinid-pluginid