### PR TITLE
Add OnInventoryItemFind and OnInventoryAmmoItemFind hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -18478,7 +18478,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "l0.inventory, this.fuelType",
             "HookTypeName": "Simple",
-            "Name": "OnInventoryAmmoItemFind",
+            "Name": "OnInventoryAmmoItemFind [Chainsaw]",
             "HookName": "OnInventoryAmmoItemFind",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "Chainsaw",
@@ -21101,6 +21101,54 @@
             },
             "MSILHash": "fcoqKk4EobNYGkzVR4q4EVkgOZfItr4P6tOM9pGuREs=",
             "HookCategory": "NPC"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryItemFind",
+            "HookName": "OnInventoryItemFind",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "FindItemByItemID",
+              "ReturnType": "Item",
+              "Parameters": [
+                "System.Int32"
+              ]
+            },
+            "MSILHash": "mIgsOlsY5+agJeJrRGUOuKUpnUOk7hvTn7l/stA0PMI=",
+            "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "HookTypeName": "Simple",
+            "Name": "OnInventoryAmmoItemFind [PlayerInventory]",
+            "HookName": "OnInventoryAmmoItemFind",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlayerInventory",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "FindAmmo",
+              "ReturnType": "Item",
+              "Parameters": [
+                "Rust.AmmoTypes"
+              ]
+            },
+            "MSILHash": "lxTpsrJ5BuajwNCtQbnXOGuXaEgTIoc900JRYZ82ohY=",
+            "HookCategory": "Item"
           }
         }
       ],


### PR DESCRIPTION
```cs
Item OnInventoryItemFind(PlayerInventory inventory, int itemid)
```

- Called when the `PlayerInventory.FindItemByItemID(int itemid)` method is called. For example, when switching ammo types with the currently held weapon, when finding armor to attach to a hot air balloon, when finding a saddle to purchase a horse, and when finding a hood to cover a player's head.
- Returning an `Item` value cancels the default behavior, and causes `PlayerInventory.FindItemByItemID(int itemid)` to return that value
- Works like the [`List<Item> OnInventoryItemsFind(PlayerInventory inventory, int itemid)`](https://github.com/OxideMod/Oxide.Rust/pull/423) hook but for when Rust is searching for only one item instead of a list of items.

```cs
Item OnInventoryAmmoItemFind(PlayerInventory inventory, AmmoTypes ammoType)
```
- Called when the `PlayerInventory.FindAmmo(AmmoTypes ammoType)` method is called. For example, when automatically switching ammo types if the currently selected ammo type is unavailable.
- Returning an `Item` value cancels the default behavior, and causes `PlayerInventory.FindAmmo(AmmoTypes ammoType)` to return that value
- This hook already exists for `Chainsaw` and `FlameThrower` types with the same signature
- This is different from `OnInventoryAmmoFind` in that it returns a single item instead of populating a list