### PR TITLE
OnPlayerHandcuff and OnPlayerHandcuffed hooks 

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -21102,6 +21102,56 @@
             "MSILHash": "fcoqKk4EobNYGkzVR4q4EVkgOZfItr4P6tOM9pGuREs=",
             "HookCategory": "NPC"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 37,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 2,
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerHandcuff",
+            "HookName": "OnPlayerHandcuff",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Handcuffs",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "SV_HandcuffVictim",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer",
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "vETQZv49Y6YCarwyOUUM1NQ6W8q4hAaqVxNg5ECry+k=",
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 155,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerHandcuffed",
+            "HookName": "OnPlayerHandcuffed",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Handcuffs",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "SV_HandcuffVictim",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer",
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "vETQZv49Y6YCarwyOUUM1NQ6W8q4hAaqVxNg5ECry+k=",
+            "BaseHookName": "OnPlayerHandcuff"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -21150,7 +21150,8 @@
               ]
             },
             "MSILHash": "vETQZv49Y6YCarwyOUUM1NQ6W8q4hAaqVxNg5ECry+k=",
-            "BaseHookName": "OnPlayerHandcuff"
+            "BaseHookName": "OnPlayerHandcuff",
+            "HookCategory": "Player"
           }
         }
       ],


### PR DESCRIPTION
OnPlayerHandcuff : check if a player is trying to handcuff an other player.
OnPlayerHandcuffed : confirmation that the player was handcuff .

private object OnPlayerHandcuff( BasePlayer victim, BasePlayer handcuffer )

//---
	Item ownerItem = base.GetOwnerItem();
	if (ownerItem == null)
	{
		return;
	}
	if (Interface.CallHook("OnPlayerHandcuff", victim, handcuffer) != null)
	{
		return;
	}
	victim.SetPlayerFlag(BasePlayer.PlayerFlags.IsRestrained, true);
	victim.SendNetworkUpdateImmediate(false);
//---

private void OnPlayerHandcuffed( BasePlayer victim, BasePlayer handcuffer )

//---
		ConVar.Inventory.EquipItemInSlot(victim, 0);
	}
	victim.ClientRPC<int, ItemId>(RpcTarget.Player("SetActiveBeltSlot", victim), ownerItem.position, ownerItem.uid);
	this.SetLocked(true, victim, ownerItem);
	Effect.server.Run(this.lockEffect.resourcePath, victim, 0u, Vector3.zero, Vector3.zero, null, false, null);
	Interface.CallHook("OnPlayerHandcuffed", victim, handcuffer);
}