### PR TITLE
HorseDung

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -53646,46 +53646,14 @@
             "HookCategory": "Clan"
           }
         },
-		{
-          "Type": "Modify",
+	{
+          "Type": "Simple",
           "Hook": {
             "InjectionIndex": 6,
-            "RemoveCount": 0,
-            "Instructions": [
-              {
-                "OpCode": "ldstr",
-                "OpType": "String",
-                "Operand": "OnDungProduction"
-              },
-              {
-                "OpCode": "ldarg_0",
-                "OpType": "None"
-              },
-              {
-                "OpCode": "ldarg_0",
-                "OpType": "None"
-              },
-              {
-                "OpCode": "ldfld",
-                "OpType": "Field",
-                "Operand": "Assembly-CSharp|BaseRidableAnimal|Dung"
-              },
-              {
-                "OpCode": "call",
-                "OpType": "Method",
-                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object)"
-              },
-              {
-                "OpCode": "brfalse_s",
-                "OpType": "Instruction",
-                "Operand": 6
-              },
-              {
-                "OpCode": "ret",
-                "OpType": "None"
-              }
-            ],
-            "HookTypeName": "Modify",
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, this.Dung",
+            "HookTypeName": "Simple",
             "Name": "OnDungProduction [BaseRidableAnimal]",
             "HookName": "OnDungProduction",
             "AssemblyName": "Assembly-CSharp.dll",
@@ -53704,7 +53672,7 @@
         {
           "Type": "Modify",
           "Hook": {
-            "InjectionIndex": 20,
+            "InjectionIndex": 21,
             "RemoveCount": 0,
             "Instructions": [
               {
@@ -53735,38 +53703,15 @@
           }
         },
         {
-          "Type": "Modify",
+          "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 47,
-            "RemoveCount": 0,
-            "Instructions": [
-              {
-                "OpCode": "ldstr",
-                "OpType": "String",
-                "Operand": "OnDungProduced"
-              },
-              {
-                "OpCode": "ldarg_0",
-                "OpType": "None"
-              },
-              {
-                "OpCode": "ldloc_1",
-                "OpType": "None"
-              },
-              {
-                "OpCode": "call",
-                "OpType": "Method",
-                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object)"
-              },
-              {
-                "OpCode": "pop",
-                "OpType": "None"
-              }
-            ],
-            "HookTypeName": "Modify",
+            "InjectionIndex": 48,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l1",
+            "HookTypeName": "Simple",
             "Name": "OnDungProduced [BaseRidableAnimal]",
             "HookName": "OnDungProduced",
-            "HookDescription": "Call of the OnDungProduced hook",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BaseRidableAnimal",
             "Flagged": false,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -53645,6 +53645,141 @@
             "BaseHookName": "OnClanLogoChanged",
             "HookCategory": "Clan"
           }
+        },
+		{
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 6,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnDungProduction"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldfld",
+                "OpType": "Field",
+                "Operand": "Assembly-CSharp|BaseRidableAnimal|Dung"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "brfalse_s",
+                "OpType": "Instruction",
+                "Operand": 6
+              },
+              {
+                "OpCode": "ret",
+                "OpType": "None"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnDungProduction [BaseRidableAnimal]",
+            "HookName": "OnDungProduction",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseRidableAnimal",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "DoDung",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "A8OVPJZPZYLqWqjNJj65EhbyrnUs4tpfVj4cYwGq5NI=",
+            "HookCategory": "Animal"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 20,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "stloc_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldloc_1",
+                "OpType": "None"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnDungProduced [BaseRidableAnimal] [Variable]",
+            "HookName": "OnDungProduced",
+            "HookDescription": "Saving the created Item to a variable for its subsequent transfer in a hook.",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseRidableAnimal",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "DoDung",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "A8OVPJZPZYLqWqjNJj65EhbyrnUs4tpfVj4cYwGq5NI=",
+            "BaseHookName": "OnDungProduction [BaseRidableAnimal]",
+            "HookCategory": "Animal"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 47,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "OnDungProduced"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldloc_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Oxide.Core|Oxide.Core.Interface|CallHook(System.String,System.Object,System.Object)"
+              },
+              {
+                "OpCode": "pop",
+                "OpType": "None"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OnDungProduced [BaseRidableAnimal]",
+            "HookName": "OnDungProduced",
+            "HookDescription": "Call of the OnDungProduced hook",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseRidableAnimal",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "DoDung",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "A8OVPJZPZYLqWqjNJj65EhbyrnUs4tpfVj4cYwGq5NI=",
+            "BaseHookName": "OnDungProduced [BaseRidableAnimal] [Variable]",
+            "HookCategory": "Animal"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Adding two hooks to track and optionally cancel Dung creation for **BaseRidableAnimal**.
At the moment, only **RidableHorse** exists.

### 1. The <ins>OnDungProduction</ins> hook is called before the creation of a dung item. Returning a non-null value overrides the default behavior.
```csharp
object OnDungProduction(BaseRidableAnimal animal, ItemDefinition itemDefinition)
{
    Puts($"{animal.GetType()} is about to produce a dung item({itemDefinition.shortname}).");
    return null;
}
```

### 2. The <ins>OnDungProduced</ins> hook is called after the dung item is created and dropped on the ground. No return behavior.
```csharp
void OnDungProduced(BaseRidableAnimal animal, Item item)
{
    Puts($"{animal.GetType()} produced a dung item({item.info.shortname}) in quantity: {item.amount}.");
}
```

#### Code before:
```csharp
private void DoDung()
{
	this.dungProduction -= 1f;
	global::ItemManager.Create(this.Dung, 1, 0uL, true).Drop(base.transform.position + -base.transform.forward + Vector3.up * 1.1f + UnityEngine.Random.insideUnitSphere * 0.1f, -base.transform.forward, default(Quaternion));
}
```

#### Code after:
```csharp
private void DoDung()
{
	this.dungProduction -= 1f;
	if (Interface.CallHook("OnDungProduction", this, this.Dung) != null)
	{
		return;
	}
	global::Item OxideGen_ = global::ItemManager.Create(this.Dung, 1, 0uL, true);
	OxideGen_.Drop(base.transform.position + -base.transform.forward + Vector3.up * 1.1f + UnityEngine.Random.insideUnitSphere * 0.1f, -base.transform.forward, default(Quaternion));
	Interface.CallHook("OnDungProduced", this, OxideGen_);
}
```