### PR TITLE
Vanish hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -53667,6 +53667,57 @@
             "BaseHookName": "OnClanLogoChanged",
             "HookCategory": "Clan"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 48,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerVanish",
+            "HookName": "OnPlayerVanish",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ConVar.Debugging",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "invis",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "IzdN5chchqSU/SzhkwmVml/q0gPr+p3c6D+Ldw1JS3U=",
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 92,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerUnvanish",
+            "HookName": "OnPlayerUnvanish",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ConVar.Debugging",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "invis",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "IzdN5chchqSU/SzhkwmVml/q0gPr+p3c6D+Ldw1JS3U=",
+            "BaseHookName": "OnPlayerVanish",
+            "HookCategory": "Player"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
As we already know, in the December update, the developers added a new command "**invis**"(Vanish).  
I suggest adding **OnVanishDisappear** and **OnVanishReappear** hooks to track the entry and exit from invisibility, similar to what is already available in the **Vanish** and **BetterVanish** plugins.

### 1. The <ins>OnVanishDisappear</ins> hook is called after the player became  <ins>invisible</ins>. No return behavior.
```csharp
void OnVanishDisappear(BasePlayer player)
{
    Puts($"Player {player.displayName} has become invisible.");
}
```

### 2. The <ins>OnVanishReappear</ins> hook is called after the player became <ins>visible</ins>. No return behavior.
```csharp
void OnVanishReappear(BasePlayer player)
{
    Puts($"Player {player.displayName} is visible again.");
}
```

#### Code before:
```csharp
[ServerVar(Help = "Make admin invisibile")]
public static void invis(ConsoleSystem.Arg arg)
{
	global::BasePlayer basePlayer = arg.Player();
	if (basePlayer == null)
	{
		return;
	}
	bool @bool = arg.GetBool(0, !Debugging.invisiblePlayers.Contains(basePlayer));
	if (@bool && !Debugging.invisiblePlayers.Contains(basePlayer))
	{
		Debugging.invisiblePlayers.Add(basePlayer);
		basePlayer.limitNetworking = true;
		basePlayer.syncPosition = false;
		global::HeldEntity expr_5D = basePlayer.GetHeldEntity();
		if (expr_5D != null)
		{
			expr_5D.SetHeld(false);
		}
		basePlayer.DisablePlayerCollider();
		Rust.Ai.SimpleAIMemory.AddIgnorePlayer(basePlayer);
		global::BaseEntity.Query.Server.RemovePlayer(basePlayer);
		if (!Global.Runner.IsInvoking(new Action(Debugging.TickInvis)))
		{
			Global.Runner.InvokeRepeating(new Action(Debugging.TickInvis), 0f, 0f);
		}
	}
	else if (!@bool && Debugging.invisiblePlayers.Contains(basePlayer))
	{
		Debugging.invisiblePlayers.Remove(basePlayer);
		basePlayer.limitNetworking = false;
		basePlayer.syncPosition = true;
		basePlayer.EnablePlayerCollider();
		Rust.Ai.SimpleAIMemory.RemoveIgnorePlayer(basePlayer);
		global::BaseEntity.Query.Server.RemovePlayer(basePlayer);
		global::BaseEntity.Query.Server.AddPlayer(basePlayer);
		if (Debugging.invisiblePlayers.Count == 0)
		{
			Global.Runner.CancelInvoke(new Action(Debugging.TickInvis));
		}
	}
	arg.ReplyWith("Invis: " + basePlayer.limitNetworking.ToString());
}
```

#### Code after:
```csharp
[ServerVar(Help = "Make admin invisibile")]
public static void invis(ConsoleSystem.Arg arg)
{
	global::BasePlayer basePlayer = arg.Player();
	if (basePlayer == null)
	{
		return;
	}
	bool @bool = arg.GetBool(0, !Debugging.invisiblePlayers.Contains(basePlayer));
	if (@bool && !Debugging.invisiblePlayers.Contains(basePlayer))
	{
		Debugging.invisiblePlayers.Add(basePlayer);
		basePlayer.limitNetworking = true;
		basePlayer.syncPosition = false;
		global::HeldEntity expr_5D = basePlayer.GetHeldEntity();
		if (expr_5D != null)
		{
			expr_5D.SetHeld(false);
		}
		basePlayer.DisablePlayerCollider();
		Rust.Ai.SimpleAIMemory.AddIgnorePlayer(basePlayer);
		global::BaseEntity.Query.Server.RemovePlayer(basePlayer);
		Interface.CallHook("OnVanishDisappear", basePlayer);//<=== OnVanishDisappear
		if (!Global.Runner.IsInvoking(new Action(Debugging.TickInvis)))
		{
			Global.Runner.InvokeRepeating(new Action(Debugging.TickInvis), 0f, 0f);
		}
	}
	else if (!@bool && Debugging.invisiblePlayers.Contains(basePlayer))
	{
		Debugging.invisiblePlayers.Remove(basePlayer);
		basePlayer.limitNetworking = false;
		basePlayer.syncPosition = true;
		basePlayer.EnablePlayerCollider();
		Rust.Ai.SimpleAIMemory.RemoveIgnorePlayer(basePlayer);
		global::BaseEntity.Query.Server.RemovePlayer(basePlayer);
		global::BaseEntity.Query.Server.AddPlayer(basePlayer);
		Interface.CallHook("OnVanishReappear", basePlayer);//<=== OnVanishReappear
		if (Debugging.invisiblePlayers.Count == 0)
		{
			Global.Runner.CancelInvoke(new Action(Debugging.TickInvis));
		}
	}
	arg.ReplyWith("Invis: " + basePlayer.limitNetworking.ToString());
}
```