### PR TITLE
issue with OnEntityReskinned not called

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -16749,7 +16749,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 526,
+            "InjectionIndex": 528,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": " l3, l7, a0.player",


### PR DESCRIPTION
OnEntityReskinned is only called when reskinning TC or LegacyFurnace 
Move callhook 2 lines down to be called every reskin

//---
					baseEntity.SetSlots(slots);
				}
				~~Interface.CallHook("OnEntityReskinned", baseEntity, skin, msg.player);~~
				Pool.FreeUnmanaged<SprayCan.ChildPreserveInfo>(ref list);
			}
			Interface.CallHook("OnEntityReskinned", baseEntity, skin, msg.player);
			base.ClientRPC<int, NetworkableId>(RpcTarget.NetworkGroup("Client_ReskinResult"), 1, baseEntity.net.ID);
		}
	}
//---