### PR TITLE
Hook OnFishCaught moved

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -15239,7 +15239,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 595,
+            "InjectionIndex": 594,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this.currentFishTarget, this, l1",


### PR DESCRIPTION
Instead of OnFishCaught being called in loop when there is a fish on the fishing line,  it will be called once when the fish is caught.

```
		fishingBobber.Kill();
		currentBobber.Set(null);
		CancelInvoke(CatchProcess);
		Interface.CallHook("OnFishCaught", currentFishTarget, this, ownerPlayer);
	}
}
```