### PR TITLE
SiegeWeapons

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -21912,6 +21912,207 @@
             "MSILHash": "PEMe9Qo7DLJ1yxndpff7pPcf3AiFoSFxKPLNylH957I=",
             "HookCategory": "Player"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 10,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnSiegeWeaponDoorOpen [BatteringRam]",
+            "HookName": "OnSiegeWeaponDoorOpen",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BatteringRam",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 1,
+              "Name": "RPC_OpenDoor",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "XZ8ilS5Ac2/3ckx66FTXqOMOB7d7U/m/7h2iH78kQ+Q=",
+            "HookCategory": "Primitive"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 10,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnSiegeWeaponDoorClose [BatteringRam]",
+            "HookName": "OnSiegeWeaponDoorClose",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BatteringRam",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 1,
+              "Name": "RPC_CloseDoor",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "1Jt6suE/Ormb6EEHrBmxeGiVKH1immH50fdMC/YVI0M=",
+            "HookCategory": "Primitive"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 14,
+            "ReturnBehavior": 4,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnSiegeWeaponPull",
+            "HookName": "OnSiegeWeaponPull",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseSiegeWeapon",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "SERVER_StartPulling",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "WV+au3i32a6i9ipirJZF0HDBg87L58lyQf6qygcrges=",
+            "HookCategory": "Primitive"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Assembly-CSharp|BaseEntity|get_OwnerID"
+              },
+              {
+                "OpCode": "stloc_0",
+                "OpType": "None"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OwnerID ConstructableEntity [patch]",
+            "HookName": "OwnerID ConstructableEntity [patch]",
+            "HookDescription": "Removal of base.Kill() call since OwnerID becomes 0 after Kill",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ConstructableEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnRepairFinished",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "qUIR6Mhvziw+jj7C8Vqk92B8gIQx16mHCTSaqFvArao=",
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 20,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "stloc_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldloc_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldloc_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Assembly-CSharp|BaseEntity|set_OwnerID"
+              },
+              {
+                "OpCode": "ldloc_1",
+                "OpType": "None"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OwnerID ConstructableEntity [patch2]",
+            "HookName": "OwnerID ConstructableEntity [patch2]",
+            "HookDescription": "Inheritance of OwnerID for siege weapons after full repair and call of the removed base.Kill()",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ConstructableEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnRepairFinished",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "qUIR6Mhvziw+jj7C8Vqk92B8gIQx16mHCTSaqFvArao=",
+            "BaseHookName": "OwnerID ConstructableEntity [patch]",
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 15,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldarg_1",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "ldarg_0",
+                "OpType": "None"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Assembly-CSharp|BaseEntity|get_OwnerID"
+              },
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Assembly-CSharp|BaseEntity|set_OwnerID"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "OwnerID SiegeTowerDoor [patch]",
+            "HookName": "OwnerID SiegeTowerDoor [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "SiegeTower",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "SetupDoor",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "SiegeTowerDoor"
+              ]
+            },
+            "MSILHash": "hB79AUeZUYWFEHlv3vKJ+VhguE2BMeLr73x/FS2Rm9c=",
+            "HookCategory": "_Patches"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Public method, new hooks and OwnerID inheritance.  

### 1. Public method <ins>DeployableSiegeExplosive::ActuallyExplode</ins>.  
At the moment, when taking any damage(except from water-based weapons), placed siege projectiles("Propane Explosive Bomb" and "Firebomb") ignite with a 100% probability, making their explosion inevitable, even if the initiator and damage in **HitInfo** are nullified in the **OnEntityTakeDamage** hook. Since the **ActuallyExplode** method is **private**, it cannot be passed to **CancelInvoke** to prevent the explosion and passing it as a string does not work.  
By making ***ActuallyExplode* public**, it becomes possible to both manually trigger the explosion and cancel it by passing **ActuallyExplode** as an action in **CancelInvoke**.
```csharp
object OnEntityTakeDamage(DeployableSiegeExplosive siegeExplosive, HitInfo info)
{
    if (info != null && info.damageTypes.GetMajorityDamageType() != DamageType.Decay && siegeExplosive.IsValid())
    {
        NextTick(() =>
        {
            if (siegeExplosive.IsValid())
            {
                siegeExplosive.SetFlag(BaseEntity.Flags.Reserved1, b: false);//Disabling fire animation
                siegeExplosive.CancelInvoke(siegeExplosive.ActuallyExplode);//Canceling delayed explosion
            }
        });
    }
    return null;
}
```  
```csharp
void OnEntitySpawned(DeployableSiegeExplosive siegeExplosive)
{
    siegeExplosive.ActuallyExplode();//Example of a 'manual' explosion on spawn
}
```  

### 2. The <ins>OnSiegeWeaponDoorOpen</ins> and <ins>OnSiegeWeaponDoorClose</ins> hooks are called before attempting to open or close the rear door of the battering ram. Returning a non-null value overrides the default behavior.  
```csharp
object OnSiegeWeaponDoorOpen(BatteringRam batteringRam, BasePlayer player)
{
    Puts($"Player '{player.displayName}' is attempting to open the battering ram door({batteringRam.net.ID.Value}).");
    return null;
}
```  
```csharp
object OnSiegeWeaponDoorClose(BatteringRam batteringRam, BasePlayer player)
{
    Puts($"Player '{player.displayName}' is attempting to close the battering ram door({batteringRam.net.ID.Value}).");
    return null;
}
```  

### 3. The <ins>OnSiegeWeaponPull</ins> hook is called before attempting to pull the siege weapon. Returning a non-null value overrides the default behavior.  
This hook works similarly to the existing **OnVehiclePush** and is only called if there is no active puller. Also, there is a patch that calls **ClientRPC(RpcTarget.NetworkGroup("CLIENT_StopPulling"));** *when a non-null* value is returned, so the player sees the '**Pull**' button again.  
```csharp
object OnSiegeWeaponPull(BaseSiegeWeapon siegeWeapon, BasePlayer player)
{
    Puts($"Player '{player.displayName}' is attempting to pull the siege weapon({siegeWeapon.net.ID.Value}).");
    return null;
}
```  

### 4. <ins>OwnerID</ins> Inheritance.  
Unfortunately, Facepunch doesn't pay much attention to modders. When a player places a crafted siege weapon(**ConstructableEntity**), it initially has an **OwnerID** equal to the **userID** of the player who placed it. However, once it is fully repaired to 100%, the **OwnerID** disappears(becomes 0).  
For some plugins, **OwnerID** is crucial. For example, in my PvE plugin, I cannot restrict damage, pulling or pushing of such siege weapons because their **OwnerID** becomes **zero**.  
Therefore, I propose adding what Facepunch overlooked.  

#### ConstructableEntity.OnRepairFinished():  
```csharp
//Before
public override void OnRepairFinished()
{
    base.OnRepairFinished();
    Kill();
    GameManager.server.CreateEntity(entityToSpawn.resourcePath, base.transform.position, base.transform.rotation).Spawn();
    if (spawnEffect.isValid)
    {
        Effect.server.Run(spawnEffect.resourcePath, base.transform.position, Vector3.up);
    }
}
//After
public override void OnRepairFinished()
{
    base.OnRepairFinished();
    BaseEntity baseEntity = GameManager.server.CreateEntity(entityToSpawn.resourcePath, base.transform.position, base.transform.rotation);//Saving to a local variable
    baseEntity.OwnerID = base.OwnerID;//OwnerID Inheritance
    Kill();//Moving the Kill method after OwnerID inheritance, as the OwnerID property is set to 0 after Kill
    baseEntity.Spawn();//Spawn call at the end
    if (spawnEffect.isValid)
    {
        Effect.server.Run(spawnEffect.resourcePath, base.transform.position, Vector3.up);
    }
}
```  

#### SiegeTower.SetupDoor():  
OwnerID inheritance for the three doors of the siege tower.  
```csharp
//Before
private void SetupDoor(SiegeTowerDoor door)
{
    door.SetupDoor(this);
    door.SetMaxHealth(MaxHealth());
    door.SetHealth(MaxHealth());
    door.startHealth = MaxHealth();
}
//After
private void SetupDoor(SiegeTowerDoor door)
{
    door.SetupDoor(this);
    door.SetMaxHealth(MaxHealth());
    door.SetHealth(MaxHealth());
    door.startHealth = MaxHealth();
    door.OwnerID = base.OwnerID;//OwnerID Inheritance
}
```