### PR TITLE
Adding a 3rd argument for the OnItemPickup hook

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -2049,7 +2049,7 @@
             "InjectionIndex": 13,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this.item, a0.player",
+            "ArgumentString": "this.item, a0.player, this",
             "HookTypeName": "Simple",
             "Name": "OnItemPickup",
             "HookName": "OnItemPickup",


### PR DESCRIPTION
In some cases, the **OnItemPickup** hook needs access to the **WorldItem** and because of this, an unnecessary call to the method **item.GetWorldEntity()** has to be made. I suggest simply adding **this**(WorldItem) as the 3rd argument.

`object OnItemPickup(Item item, BasePlayer player, WorldItem worldItem)`  
`object OnItemPickup(Item item, BasePlayer player, DroppedItem droppedItem)`

Ideally, it would probably be better to call `object OnItemPickup(WorldItem worldItem, BasePlayer player)` and get the Item through **worldItem.item**, but this would break plugins, so it's better to simply add it at the end to avoid affecting other plugins.

Thank you!