### PR TITLE
Fix permission check for resolved users

### DIFF
--- a/src/RustCommands.cs
+++ b/src/RustCommands.cs
@@ -85,7 +85,7 @@ namespace Oxide.Game.Rust
                     permission.UpdateNickname(userId, name);
                 }
 
-                if (permission.UserHasPermission(name, perm))
+                if (permission.UserHasPermission(userId, perm))
                 {
                     player.Reply(string.Format(lang.GetMessage("PlayerAlreadyHasPermission", this, player.Id), userId, perm));
                     return;


### PR DESCRIPTION
Fixes `oxide.grant user <name> <permission>` checking the resolved player's name instead of their user ID.

The permission check now uses the same resolved `userId` as the grant itself.